### PR TITLE
move PROJECT from XML to an optional argument to create_postprocess.

### DIFF
--- a/Machines/machine_postprocess.xml
+++ b/Machines/machine_postprocess.xml
@@ -14,7 +14,6 @@
       <include>-I/glade/apps/opt/netcdf/4.2/intel/12.1.5/include</include>
       <libs>-L/glade/apps/opt/netcdf/4.2/intel/12.1.5/lib -lnetcdff -lnetcdf</libs>
     </za>
-    <project></project>
     <reset_modules>
       <module>module restore system</module>
       <module>module load python/2.7.7</module>
@@ -72,7 +71,6 @@
       <include>-I/glade/u/apps/ch/opt/netcdf/4.4.1.1/intel/16.0.3/include</include>
       <libs>-L/glade/u/apps/ch/opt/netcdf/4.4.1.1/intel/16.0.3/lib -lnetcdff -lnetcdf</libs>
     </za>
-    <project></project>
     <reset_modules>
       <module>module restore system</module>
       <module>module load python/2.7.13</module>
@@ -131,7 +129,6 @@
       <include>-I-I/opt/cray/netcdf/4.3.2/INTEL/140/include</include>
       <libs>-L/opt/cray/netcdf/4.3.2/INTEL/140/lib -lnetcdff -L/opt/cray/hdf5/1.8.13/INTEL/140/lib -lnetcdf</libs>
     </za>
-    <project></project>
     <reset_modules>
       <module>module restore system</module>
       <module>module load python/2.7.7</module>

--- a/Machines/machine_postprocess.xsd
+++ b/Machines/machine_postprocess.xsd
@@ -16,7 +16,6 @@
   <xs:element name="module" type="xs:string" />
   <xs:element name="mpi_command" type="xs:string"/>
   <xs:element name="pythonpath" type="xs:string"/>
-  <xs:element name="project" type="xs:string"/>
   <xs:element name="obs_root" type="xs:string"/>
   <xs:element name="compiler" type="xs:string"/>
   <xs:element name="flags" type="xs:string"/>
@@ -143,7 +142,6 @@
 	<xs:element ref="pythonpath" minOccurs="0" maxOccurs="1"/>
 	<xs:element ref="f2py" minOccurs="0" maxOccurs="1"/>
 	<xs:element ref="za" minOccurs="0" maxOccurs="1"/>
-	<xs:element ref="project" minOccurs="0" maxOccurs="1"/>
 	<xs:element ref="modules" minOccurs="0" maxOccurs="1"/>
 	<xs:element ref="components" minOccurs="0" maxOccurs="1"/>
       </xs:sequence>

--- a/cesm_utils/cesm_utils/create_postprocess
+++ b/cesm_utils/cesm_utils/create_postprocess
@@ -135,6 +135,9 @@ def commandline_options():
     parser.add_argument('-cesmtag', '--cesmtag', nargs=1, required=False,
                         help='CESM repository tag (optional)')
 
+    parser.add_argument('-project', '--project', nargs=1, required=False,
+                        help='Project code (optional). This setting will override the environment variable setting.')
+
     options = parser.parse_args()
         
     return options
@@ -289,11 +292,6 @@ def read_machine_xml(machineName, xmlFile):
             machine['pythonpath'] = xmlmachine.find('pythonpath').text
             if machine['pythonpath'] is None:
                 machine['pythonpath'] = ''
-
-            # get the project from the XML first then override with env setting
-            machine['project'] = xmlmachine.find('project').text
-            if os.getenv('PROJECT') is not None:
-                machine['project'] = os.getenv('PROJECT')
 
             # loop through the reset_module list
             for mod in xmlmachine.findall("reset_modules/module"):
@@ -490,6 +488,11 @@ def initialize_main(envDict, options, standalone):
     if options.cesmtag:
         envDict['CESM_TAG'] = options.cesmtag[0]
 
+    # set the project code
+    envDict['PROJECT'] = os.getenv('PROJECT')
+    if options.project:
+        envDict['PROJECT'] = options.project[0]
+
     return envDict
 
 # -------------------------------------------------------------------------------
@@ -591,7 +594,7 @@ def main(options):
     outFile = '{0}/{1}'.format(envDict['PP_CASE_PATH'],processName)
 
     create_batch(envDict['POSTPROCESS_PATH'], machine['timeseries_pes'], batch_tmpl, run_tmpl, postProcessCmd, 
-                 machine['mpi_command'], outFile, processName, machine['project'], machine['pythonpath'], 
+                 machine['mpi_command'], outFile, processName, envDict['PROJECT'], machine['pythonpath'], 
                  envDict['PP_CASE_PATH'], machine['reset_modules'], machine['modules'], 
                  machine['timeseries_queue'], machine['timeseries_ppn'], machine['timeseries_nodes'], 
                  machine['timeseries_wallclock'], options, standalone)
@@ -604,7 +607,7 @@ def main(options):
         outFile = '{0}/{1}'.format(envDict['PP_CASE_PATH'], processName)
         create_batch(envDict['POSTPROCESS_PATH'], machine['{0}_averages_pes'.format(comp)], batch_tmpl, 
                      run_tmpl, postProcessCmd, machine['mpi_command'], outFile, processName, 
-                     machine['project'], machine['pythonpath'], envDict['PP_CASE_PATH'], 
+                     envDict['PROJECT'], machine['pythonpath'], envDict['PP_CASE_PATH'], 
                      machine['reset_modules'], machine['modules'], machine['{0}_averages_queue'.format(comp)], 
                      machine['{0}_averages_ppn'.format(comp)], machine['{0}_averages_nodes'.format(comp)], 
                      machine['{0}_averages_wallclock'.format(comp)], options, standalone)
@@ -615,7 +618,7 @@ def main(options):
         outFile = '{0}/{1}'.format(envDict['PP_CASE_PATH'], processName)
         create_batch(envDict['POSTPROCESS_PATH'], machine['{0}_diagnostics_pes'.format(comp)], batch_tmpl, 
                      run_tmpl, postProcessCmd, machine['mpi_command'], outFile, processName, 
-                     machine['project'], machine['pythonpath'], envDict['PP_CASE_PATH'],  
+                     envDict['PROJECT'], machine['pythonpath'], envDict['PP_CASE_PATH'],  
                      machine['reset_modules'], machine['modules'], 
                      machine['{0}_diagnostics_queue'.format(comp)],
                      machine['{0}_diagnostics_ppn'.format(comp)], 
@@ -630,7 +633,7 @@ def main(options):
         outFile = '{0}/{1}'.format(envDict['PP_CASE_PATH'], processName)
         create_batch(envDict['POSTPROCESS_PATH'], machine['{0}_regrid_pes'.format(comp)], batch_tmpl, 
                      run_tmpl, postProcessCmd, machine['mpi_command'], outFile, processName, 
-                     machine['project'], machine['pythonpath'], envDict['PP_CASE_PATH'],  
+                     envDict['PROJECT'], machine['pythonpath'], envDict['PP_CASE_PATH'],  
                      machine['reset_modules'], machine['modules'], machine['{0}_regrid_queue'.format(comp)], 
                      machine['{0}_regrid_ppn'.format(comp)], machine['{0}_regrid_nodes'.format(comp)],
                      machine['{0}_regrid_wallclock'.format(comp)], options, standalone)


### PR DESCRIPTION
The PROJECT code variable had been set in the machine_postprocess.xml but
this doesn't work in a shared install of the virtualenv. So, moved the project
setting to be a command line option to create_postprocess as:

create_postprocess --caseroot [path-to-caseroot] {--project [project-code] 
                                  --cesmtag [cesm-release-tag] --debug [level] --backtrace}