### PR TITLE
fixes for cheyenne PE settings 

### DIFF
--- a/Config/config_postprocess.xml
+++ b/Config/config_postprocess.xml
@@ -131,7 +131,7 @@
       <entry id="TIMESERIES_COMPLETECHUNK" 
 	     type="logical"
 	     valid_values="TRUE,FALSE"  
-	     value="TRUE" 
+	     value="FALSE" 
 	     group="postprocess"
 	     desc="If TRUE, create only complete chunks of variable timeseries data files as determined by the env_timeseries.xml tseries_filecat_tper and tseries_filecat_n elements. If FALSE, then incomplete chunks of variable timeseries data will be created and appended to upon subsequent running of the timeseries script. Default is TRUE."
 	     ></entry> 
@@ -155,7 +155,7 @@
       <entry id="GENERATE_AVGS_ATM"  
 	     type="logical"
 	     valid_values="TRUE,FALSE"  
-	     value="TRUE" 
+	     value="FALSE" 
 	     group="postprocess"
 	     desc="If TRUE, this calls the atm_averages script which launches the parallel python wrapper script atm_avg_generator.py to generate climatological files using the pyAverager tool. Settings for creating the averages are specified in the env_diags_atm.xml file."
 	     ></entry> 
@@ -163,7 +163,7 @@
       <entry id="GENERATE_DIAGS_ATM"  
 	     type="logical"
 	     valid_values="TRUE,FALSE"  
-	     value="TRUE" 
+	     value="FALSE" 
 	     group="postprocess"
 	     desc="If TRUE, this calls the atm_diagnostics script with launches the  AMWG diagnostics package parallel python wrapper script atm_diags_generator.py to generate climatological plots associated with the run job output. See the AMWG diagnostics documentation for more details. Settings for creating the diagnostics are specified in the env_diags_atm.xml file."
 	     ></entry> 
@@ -171,7 +171,7 @@
       <entry id="GENERATE_AVGS_ICE"  
 	     type="logical"
 	     valid_values="TRUE,FALSE"  
-	     value="TRUE" 
+	     value="FALSE" 
 	     group="postprocess"
 	     desc="If TRUE, this calls the ice_averages script which launches the parallel python wrapper script ice_avg_generator.py to generate climatological files using the pyAverager tool. Settings for creating the averages are specified in the env_diags_ice.xml file."
 	     ></entry> 
@@ -179,7 +179,7 @@
       <entry id="GENERATE_DIAGS_ICE"  
 	     type="logical"
 	     valid_values="TRUE,FALSE"  
-	     value="TRUE" 
+	     value="FALSE" 
 	     group="postprocess"
 	     desc="If TRUE, this calls the ice_diagnostics script which launches the PCWG diagnostics package parallel python wrapper script ice_diags_generator.py to generate climatological plots associated with the run job output. See the PCWG diagnostics documentation for more details. Settings for creating the diagnostics are specified in the env_diags_ice.xml file."
 	     ></entry> 
@@ -187,7 +187,7 @@
       <entry id="GENERATE_AVGS_LND"  
 	     type="logical"
 	     valid_values="TRUE,FALSE"  
-	     value="TRUE" 
+	     value="FALSE" 
 	     group="postprocess"
 	     desc="If TRUE, this calls the lnd_averages script which launches the parallel python wrapper script lnd_avg_generator.py to generate climatological files using the pyAverager tool. Settings for creating the averages are specified in the env_diags_lnd.xml file."
 	     ></entry> 
@@ -203,7 +203,7 @@
       <entry id="GENERATE_DIAGS_LND"  
 	     type="logical"
 	     valid_values="TRUE,FALSE"  
-	     value="TRUE" 
+	     value="FALSE" 
 	     group="postprocess"
 	     desc="If TRUE, this calls the lnd_diagnostics script which launches the LMWG diagnostics package parallel python wrapper script lnd_diags_generator.py to generate climatological plots associated with the run job output. See the LMWG diagnostics documentation for more details. Settings for creating the diagnostics are specified in the env_diags_lnd.xml file."
 	     ></entry> 
@@ -211,7 +211,7 @@
       <entry id="GENERATE_AVGS_OCN"  
 	     type="logical"
 	     valid_values="TRUE,FALSE"  
-	     value="TRUE" 
+	     value="FALSE" 
 	     group="postprocess"
 	     desc="If TRUE, this calls the ocn_averages script which launches the parallel python wrapper script ocn_avg_generator.py to generate climatological files using the pyAverager tool. Settings for creating the averages are specified in the env_diags_ocn.xml file."
 	     ></entry> 
@@ -219,7 +219,7 @@
       <entry id="GENERATE_DIAGS_OCN" 
 	     type="logical"
 	     valid_values="TRUE,FALSE"  
-	     value="TRUE" 
+	     value="FALSE" 
 	     group="postprocess"
 	     desc="If TRUE, this calls the OMWG diagnostics package parallel python wrapper script to generate climatological plots associated with the run job output. See the OMWG diagnostics documentation for more details. Settings for creating the diagnostics are specified in the env_diags_ocn.xml file."
 	     ></entry> 

--- a/Machines/machine_postprocess.xml
+++ b/Machines/machine_postprocess.xml
@@ -47,7 +47,7 @@
       </component>
       <component name="lnd">
 	<averages_pes queue="regular" pes_per_node="15" wallclock="02:00">120</averages_pes>
-	<diagnostics_pes queue="geyser" pes_per_node="4" wallclock="02:00">12</diagnostics_pes>
+ 	<diagnostics_pes queue="geyser" pes_per_node="4" wallclock="02:00">12</diagnostics_pes>
 	<regrid_pes queue="geyser" pes_per_node="2" wallclock="02:00">6</regrid_pes>
 	<obs_root>/glade/p/cesm/lmwg/diag/lnd_diag_data</obs_root>
       </component>
@@ -60,7 +60,7 @@
   </machine>
 
   <machine name="cheyenne" hostname="cheyenne">
-    <timeseries_pes queue="regular" nodes="14" pes_per_node="36" wallclock="00:30:00">502</timeseries_pes>
+    <timeseries_pes queue="regular" nodes="2" pes_per_node="36" wallclock="00:30:00">72</timeseries_pes>
     <mpi_command>mpirun -n {{ pes }}</mpi_command>
     <pythonpath></pythonpath>
     <f2py fcompiler="gfortran" f77exec="/glade/u/apps/ch/opt/gnu/6.2.0/bin/gfortran" 
@@ -88,30 +88,29 @@
       <module>module load nco/4.6.2</module>
       <module>module load netcdf4-python/1.2.7</module>
       <module>module load cf_units/1.1.3</module>
-      <module>module use /glade/u/apps/contrib/ncl-nightly/modules</module>
-      <module>module load ncltest-intel</module>
+      <module>module load ncl/6.3.0</module>
     </modules>
     <components>
       <component name="atm">
 	<averages_pes queue="regular" nodes="2" pes_per_node="36" wallclock="01:00:00">72</averages_pes>
-	<diagnostics_pes queue="small" nodes="1" pes_per_node="4" wallclock="01:00:00">36</diagnostics_pes>
-	<regrid_pes queue="small" nodes="1" pes_per_node="2" wallclock="01:00:00">6</regrid_pes>
+	<diagnostics_pes queue="regular" nodes="1" pes_per_node="36" wallclock="01:00:00">36</diagnostics_pes>
+	<regrid_pes queue="small" nodes="1" pes_per_node="6" wallclock="01:00:00">6</regrid_pes>
 	<obs_root>/glade/p/cesm/amwg/amwg_data</obs_root>
       </component>
       <component name="ice">
 	<averages_pes queue="regular" nodes="2" pes_per_node="36" wallclock="01:00:00">72</averages_pes>
-	<diagnostics_pes queue="small" nodes="1" pes_per_node="2" wallclock="01:00:00">4</diagnostics_pes>
+	<diagnostics_pes queue="small" nodes="1" pes_per_node="4" wallclock="01:00:00">4</diagnostics_pes>
 	<obs_root>/glade/p/cesm/pcwg/ice/data</obs_root>
       </component>
       <component name="lnd">
 	<averages_pes queue="regular" nodes="2" pes_per_node="36" wallclock="01:00:00">72</averages_pes>
-	<diagnostics_pes queue="small" nodes="1" pes_per_node="4" wallclock="01:00:00">12</diagnostics_pes>
-	<regrid_pes queue="small" nodes="1" pes_per_node="2" wallclock="01:00:00">6</regrid_pes>
+	<diagnostics_pes queue="small" nodes="1" pes_per_node="12" wallclock="01:00:00">12</diagnostics_pes>
+	<regrid_pes queue="small" nodes="1" pes_per_node="6" wallclock="01:00:00">6</regrid_pes>
 	<obs_root>/glade/p/cesm/lmwg/diag/lnd_diag_data</obs_root>
       </component>
       <component name="ocn">
 	<averages_pes queue="regular" nodes="2" pes_per_node="36" wallclock="01:00:00">72</averages_pes>
-	<diagnostics_pes queue="small" nodes="1" pes_per_node="4" wallclock="01:00:00">24</diagnostics_pes>
+	<diagnostics_pes queue="small" nodes="1" pes_per_node="24" wallclock="01:00:00">24</diagnostics_pes>
 	<obs_root>/glade/p/cesm/</obs_root>
       </component>
     </components>

--- a/Templates/batch_cheyenne.tmpl
+++ b/Templates/batch_cheyenne.tmpl
@@ -45,3 +45,4 @@
 
 . /glade/u/apps/ch/opt/lmod/7.2.1/lmod/lmod/init/bash
 
+export I_MPI_DEVICE=rdma


### PR DESCRIPTION
This PR fixes some inconsistencies that were introduced in PR #55 between
the postprocessing timeseries submission script and the cylc workflow.

It also added env var 
I_MPI_DEVICE=rdma 
to the  cheyenne submission scripts per CISL help desk ticket 145062 suggestion.

Successfully tested with timeseries generation for Simone's ASD run b.e15.B5505C5WCCML45CNR.f09_g16.control.cam5_4.002