### PR TITLE
update for cf_units on yellowstone to be included in PYTHONPATH 

### DIFF
--- a/Machines/machine_postprocess.xml
+++ b/Machines/machine_postprocess.xml
@@ -6,7 +6,7 @@
     <!-- restricting to geyser for CMIP6 and problem with scaling of the chunking -->
     <timeseries_pes queue="geyser" pes_per_node="4" wallclock="02:00">32</timeseries_pes>
     <mpi_command>mpirun.lsf</mpi_command>
-    <pythonpath></pythonpath>
+    <pythonpath>/glade/apps/opt/python/2.7.7/gnu-westmere/4.8.2/lib/python2.7/site-packages</pythonpath>
     <f2py fcompiler="gfortran" f77exec="/usr/bin/gfortran">f2py</f2py>
     <za>
       <compiler>ifort</compiler>
@@ -29,7 +29,6 @@
       <module>module load netcdf/4.3.0</module>
       <module>module load nco/4.4.4</module>
       <module>module load netcdf4python/1.1.1</module>
-      <module>module load cf_units/1.1</module>
       <module>module use /glade/apps/contrib/ncl-nightly/modules</module>
       <module>module load ncltest-intel</module>
     </modules>

--- a/Tools/ration_example.py
+++ b/Tools/ration_example.py
@@ -1,8 +1,18 @@
 #!/usr/bin/env python
+import sys
 
-from asaptools import simplecomm
+try:
+    from asaptools import simplecomm
+except:
+    print 'asaptools not loaded. exiting...'
+    sys.exit(1)
 
-scomm = simplecomm.create_comm()
+try:
+    scomm = simplecomm.create_comm(serial=False)
+except:
+    print 'unable to create scomm. exiting...'
+    sys.exit(1)
+
 rank = scomm.get_rank()
 size = scomm.get_size()
 
@@ -30,3 +40,5 @@ print '{0}/{1}: Out of loop'.format(rank, size)
 scomm.sync()
 if scomm.is_manager():
     print 'Done.'
+
+sys.exit(0)

--- a/Tools/ration_script
+++ b/Tools/ration_script
@@ -8,7 +8,7 @@
 #BSUB -q geyser
 #BSUB -N
 #BSUB -a poe
-#BSUB -J CESM_postprocessing
+#BSUB -J ration_script
 #BSUB -W 00:02
 #BSUB -P P93300606 
 
@@ -16,7 +16,11 @@
 
 export MP_LABELIO=yes
 
+module load python/2.7.7
+
 . /glade/p/work/aliceb/sandboxes/dev/postprocessing/cesm-env2/bin/activate
+
+module load mpi4py/2.0.0
 
 mpirun.lsf ./ration_example.py >> ./ration.log
 


### PR DESCRIPTION
The cf_units module was moved into the default python site_packages location on 
yellowstone at:

/glade/apps/opt/python/2.7.7/gnu-westmere/4.8.2/lib/python2.7/site-packages/cf_units-1.1-py2.7.egg

Updated the machines_postprocess.xml PYTHONPATH element to include this new path.

Tested using data from b.e20.B1850.f09_g16.pi_control.all.136 to generate timeseries files.