### PR TITLE
fixes for CISM timeseries, ocn diags and atm diags

### DIFF
--- a/Config/config_timeseries.xml
+++ b/Config/config_timeseries.xml
@@ -391,6 +391,9 @@
         <tseries_filecat_n>10</tseries_filecat_n>
       </file_extension>
     </files>
+    <tseries_time_variant_variables>
+      <variable>time</variable>
+    </tseries_time_variant_variables>
   </comp_archive_spec>
 
   <comp_archive_spec name="ww3">

--- a/Tools/ration.log
+++ b/Tools/ration.log
@@ -1,0 +1,64 @@
+Execute poe command line: poe  ./ration_example.py
+0:0/4: Sent 0
+1:1/4: Recvd 0
+1:1/4: Recvd 1
+0:0/4: Sent 1
+0:0/4: Sent 2
+1:1/4: Recvd 2
+0:0/4: Sent 3
+1:1/4: Recvd 3
+0:0/4: Sent 4
+1:1/4: Recvd 4
+0:0/4: Sent 5
+1:1/4: Recvd 5
+0:0/4: Sent 6
+1:1/4: Recvd 6
+0:0/4: Sent 7
+1:1/4: Recvd 7
+0:0/4: Sent 8
+1:1/4: Recvd 8
+0:0/4: Sent 9
+1:1/4: Recvd 9
+0:0/4: Sent None
+1:1/4: Recvd None
+1:1/4: Out of loop
+0:0/4: Sent None
+0:0/4: Sent None
+0:0/4: Out of loop
+2:2/4: Recvd None
+2:2/4: Out of loop
+3:3/4: Recvd None
+3:3/4: Out of loop
+0:Done.
+Execute poe command line: poe  ./ration_example.py
+0:0/4: Sent 0
+1:1/4: Recvd 0
+1:1/4: Recvd 1
+0:0/4: Sent 1
+0:0/4: Sent 2
+1:1/4: Recvd 2
+0:0/4: Sent 3
+1:1/4: Recvd 3
+0:0/4: Sent 4
+1:1/4: Recvd 4
+0:0/4: Sent 5
+0:0/4: Sent 6
+1:1/4: Recvd 6
+0:0/4: Sent 7
+2:2/4: Recvd 5
+0:0/4: Sent 8
+1:1/4: Recvd 8
+3:3/4: Recvd 7
+0:0/4: Sent 9
+2:2/4: Recvd 9
+0:0/4: Sent None
+1:1/4: Recvd None
+1:1/4: Out of loop
+0:0/4: Sent None
+3:3/4: Recvd None
+3:3/4: Out of loop
+0:0/4: Sent None
+0:0/4: Out of loop
+2:2/4: Recvd None
+2:2/4: Out of loop
+0:Done.

--- a/atm_diag/plot_improve_scatter_pdf.ncl
+++ b/atm_diag/plot_improve_scatter_pdf.ncl
@@ -112,9 +112,10 @@ begin
    nca = 2
  end if
  vars =(/"SO2","SO4","BC","OC","NH4NO3"/)
+ varsn =(/"SO~B~2~N~","SO~B~4~N~","BC","OC","NH~B~4~N~NO~B~3~N~"/)
  vars_data =(/"so2","so4","ec","oc","nh4no3"/)
  data_n =(/"SO2_","SO4_","EC_","OC_","NH4NO3_"/)
- vars_units = (/"ppv","ug/m3","ug/m3","ug/m3","ug/m3"/)
+ vars_units = (/"ug/m~S~3~N~","ug/m~S~3~N~","ug/m~S~3~N~","ug/m~S~3~N~","ug/m~S~3~N~"/)
 ;qmin = (/0.01,0.01,0.005
 ;qmax = (/5.,   10.,
  nvars = dimsizes(vars)
@@ -142,7 +143,8 @@ begin
  end if
 
 ; calculate plotting values
-do i = 0, nvars-1
+do i = 0, nvars-2
+ print(vars(i))
   if (compare .eq. "OBS") then
    nca = 1
   else                        ;  CASE 2 IS MODEL
@@ -189,8 +191,18 @@ do i = 0, nvars-1
           delete(varsoa)
           varsoa = (/"CB1","CB2"/)
          else
-          delete(varsoa)
-          varsoa = (/"bc_a1"/)
+           if (isfilevar(inptr,"bc_a1")) then
+            delete(varsoa)
+            varsoa = (/"bc_a1"/)
+           end if
+           if (isfilevar(inptr,"bc_a1") .and. isfilevar(inptr,"bc_a4")) then
+            delete(varsoa)
+            varsoa = (/"bc_a1","bc_a4"/)
+           end if
+           if (isfilevar(inptr,"bc_a1") .and. isfilevar(inptr,"bc_a3")) then
+            delete(varsoa)
+            varsoa = (/"bc_a1","bc_a3"/)
+           end if
          end if
    end if
    varsoa1 = -1
@@ -200,23 +212,42 @@ do i = 0, nvars-1
           delete(varsoa1)
           varsoa1 = (/"OC1","OC2"/)
          else
-          delete(varsoa1)
-          varsoa1 = (/"pom_a1"/)
+           if (isfilevar(inptr,"pom_a1")) then
+            delete(varsoa1)
+            varsoa1 = (/"pom_a1"/)
+           end if
+           if (isfilevar(inptr,"pom_a1") .and. isfilevar(inptr,"pom_a4")) then
+            delete(varsoa1)
+            varsoa1 = (/"pom_a1","pom_a4"/)
+           end if
+           if (isfilevar(inptr,"pom_a1") .and. isfilevar(inptr,"pom_a3")) then
+            delete(varsoa1)
+            varsoa1 = (/"pom_a1","pom_a3"/)
+           end if
          end if
         ; function SOA Colette
         if (isfilevar(inptr,"SOAI") .and. isfilevar(inptr,"SOAT") .and. isfilevar(inptr,"SOAB") .and. isfilevar(inptr,"SOAX") .and. isfilevar(inptr,"SOAM")) then
           delete(varsoa2)
           varsoa2 = (/"SOAI","SOAT","SOAB","SOAX","SOAM"/)
-        else 
-          if (isfilevar(inptr,"soa_a1") .and. isfilevar(inptr,"soa_a2")) then
-            delete(varsoa2)
-            varsoa2 =  (/"soa_a1","soa_a2"/)
-          else 
-            if (isfilevar(inptr,"SOA")) then
+        end if
+        if (isfilevar(inptr,"SOA")) then
                 delete(varsoa2)
                 varsoa2 =  (/"SOA"/)
-            end if
+        end if
+        if (isfilevar(inptr,"soa_a1") .and. isfilevar(inptr,"soa_a2")) then
+            delete(varsoa2)
+            varsoa2 =  (/"soa_a1","soa_a2"/)
+        else
+          if (isfilevar(inptr,"soaff1_a1") .and. isfilevar(inptr,"soaff1_a2")) then
+            delete(varsoa2)
+            varsoa2 =  (/"soaff1_a1","soaff1_a2","soaff2_a1","soaff2_a2","soaff3_a1","soaff3_a2","soaff4_a1","soaff4_a2","soaff5_a1","soaff5_a2",\
+               "soabb1_a1","soabb1_a2","soabb2_a1","soabb2_a2","soabb3_a1","soabb3_a2","soabb4_a1","soabb4_a2","soabb5_a1","soabb5_a2",\
+               "soabg1_a1","soabg1_a2","soabg2_a1","soabg2_a2","soabg3_a1","soabg3_a2","soabg4_a1","soabg4_a2","soabg5_a1","soabg5_a2" /)
           end if
+          if (isfilevar(inptr,"soa1_a1") .and. isfilevar(inptr,"soa1_a2")) then
+           delete(varsoa2)
+           varsoa2 =  (/"soa_a1","soa_a2","soa2_a1","soa2_a2","soa3_a1","soa3_a2","soa4_a1","soa4_a2","soa5_a1","soa5_a2"/)
+          end if 
         end if
         delete(varsoa)
         varsoa = array_append_record(varsoa1,varsoa2,0)
@@ -243,20 +274,22 @@ do i = 0, nvars-1
       var11 = var11a(0,nlev-1,:,:)
       delete(var11a)
       if vars(i).eq."SO2" then
+        ; SO2 improve in ug/m3
         ; convert mmr to  kg/kg
-        var11 = var11* 64./28.97 
+        if var11@units.ne."kg/kg" then 
+          var11 = var11* 64./28.97 
+        end if
       end if
-      if vars(i).eq."SO4" .and. (vinta .eq. "so4_a1" .or. vinta .eq. "so4_a2" .or. vinta .eq. "so4_3") then 
+      if vars(i).eq."SO4" .and. (vinta .eq. "so4_a1" .or. vinta .eq. "so4_a2" .or. vinta .eq. "so4_a3") then 
          var11 = var11*96.06/115.11  ; adjust that SO4 is really SO4NO3
       end if
-      if vars(i).eq."pom_a1" then
-        var11 = var11* 0.714286 
+;     if vars(i).eq."pom_a1" then
+;       var11 = var11* 0.714286 
+;     end if
+      if vars(i).eq."SOA" .and. (vinta .eq. "SOAI" .or. vinta .eq. "SOAM" .or. vinta .eq. "SOAB" .or. vinta .eq. "SOAT" .or. vinta .eq. "SOAX") then 
+          var11 = var11*mwsoa_c(si)/mwsoa(si) 
       end if
-;     if vars(i).eq."SOA" .and. (vinta .eq. "SOAI" .or. vinta .eq. "SOAM" .or. vinta .eq. "SOAB" .or. vinta .eq. "SOAT" .or. vinta .eq. "SOAX") then 
-;         var11 = var11*mwsoa_c(si)/mwsoa(si) 
-    else
-     var11 = var11@_FillValue 
-    end if
+   end if
    if ca.eq.0 then
      if si.eq.0 then
       var1 = var11
@@ -275,7 +308,8 @@ do i = 0, nvars-1
   delete(varsoa)
   delete(var11)
  end do ; ca
- var1 = var1 * rho1 * 1.e9 ; convert from kg/kg to ug/m3 ; ppb for SO2
+
+ var1 = var1 * rho1 * 1.e9 ; convert from kg/kg to ug/m3 ;
  var1@_FillValue = -999 
  var1!0 = "lat"
  var1!1 = "lon"
@@ -295,7 +329,7 @@ do i = 0, nvars-1
 
 
 ; load data and interpolate model to station location
- dir = "/glade/p/acd/tilmes/amwg/amwg_diag_20131004_work/obs_data/"
+;dir = "$OBS_DATA/cam-chem/"
   
  stn_name = systemfunc("ls $OBS_DATA/cam-chem/"+data_n(i)+"IMPROVE*nc")
  do nstn=0,dimsizes(stn_name)-1
@@ -432,20 +466,21 @@ res@trXAxisType = "LogAxis"
 
    
   ;  loop over variables     
-   do i  = 0, nvars -1
+   do i  = 0, nvars -2
      Xdata(0,:) = (/stn_ann_avg_obs(i,:)/)
      Ydata(0,:) = (/stn_ann_avg_mod1(i,:)/)
      
     if (.not.all(ismissing(Xdata(0,:)))) then
      ccro=esccr(Xdata(0,:),Xdata(0,:),0)
-     avg_obs=avg(Xdata(0,:))
+     avg_obs = dim_median(Xdata(0,:))
     else
       ccro = 0.
       avg_obs = 0.
     end if
     if (.not.all(ismissing(Ydata(0,:)))) then
      ccr1=esccr(Xdata(0,:),Ydata(0,:),0)
-     avg_mod1=avg(Ydata(0,:))
+     avg_mod1=dim_median(Ydata(0,:))
+  ;  avg_mod1=avg(Ydata(0,:))
     else
      avg_mod1 = 0.
      ccr1 = 0.
@@ -456,7 +491,14 @@ res@trXAxisType = "LogAxis"
       Ydata(1,:) = (/stn_ann_avg_mod2(i,:)/)
       if (.not.all(ismissing(Xdata(1,:)))) then
        ccr2=esccr(Xdata(1,:),Ydata(1,:),0)
-       avg_mod2=avg(Ydata(1,:))
+   ;   ins = ind(Xdata(1,:).gt.0)
+       avg_mod2=dim_median(Ydata(1,:))
+     ; avg_mod2=stat_medrng(Ydata(1,:))
+  ;    print(Ydata(0,ins))
+  ;    print(Ydata(1,ins))
+  ;  print(avg_obs)
+  ;  print(avg_mod1)
+  ;  print(avg_mod2)
       else
        ccr2 = 0.
        avg_mod2 = 0.
@@ -473,7 +515,7 @@ res@trXAxisType = "LogAxis"
 
      res@tiXAxisString = "Observed "+vars(i)+" ("+vars_units(i)+")"
      res@tiYAxisString = "Simulated "+vars(i)+" ("+vars_units(i)+")"
-     res@gsnLeftString = vars(i)+" ("+vars_units(i)+")" 
+     res@gsnLeftString = varsn(i)+" ("+vars_units(i)+")" 
 
 
         res@pmLegendDisplayMode    = "Always"
@@ -509,26 +551,27 @@ res@trXAxisType = "LogAxis"
     txres@txPerimOn             = False
     txres@txJust        = "CenterLeft"
     txres@txBackgroundFillColor = 0
-    txres@txFontHeightF         = 0.013
+    txres@txFontHeightF         = 0.015
     aaa=log10(qmax)
     bbb=log10(qmin)
     aba=(aaa-bbb)/2
 
-    txid2 = gsn_add_text(wks, plot(i), "mean_test="+sprintf("%5.2f",avg_mod1)+" R="+sprintf("%5.2f",ccr1), qmin+qmin*0.2, 10.^(aaa-0.2*aba),txres)
-    txid3 = gsn_add_text(wks, plot(i), "mean_obs="+sprintf("%5.2f",avg_obs),qmin+qmin*.2, 10.^(aaa-0.1*aba),txres)
+    txid3 = gsn_add_text(wks, plot(i), "Median Obs="+sprintf("%5.2f",avg_obs),qmin+qmin*.2, 10.^(aaa-0.1*aba),txres)
+    txres@txFontColor = "blue"
+    txid2 = gsn_add_text(wks, plot(i), "Median ="+sprintf("%5.2f",avg_mod1)+" R="+sprintf("%5.2f",ccr1), qmin+qmin*0.2, 10.^(aaa-0.2*aba),txres)
     if (compare .eq. "OBS") then
     else
-     txid1 = gsn_add_text(wks, plot(i),  "mean_cntl="+sprintf("%5.2f",avg_mod2)+" R="+sprintf("%5.2f",ccr2), qmin+qmin*0.2, 10.^(aaa-0.3*aba), txres)
+     txres@txFontColor = "red"
+     txid1 = gsn_add_text(wks, plot(i),  "Median ="+sprintf("%5.2f",avg_mod2)+" R="+sprintf("%5.2f",ccr2), qmin+qmin*0.2, 10.^(aaa-0.3*aba), txres)
     end if
-
-
+    txres@txFontColor = "black"
 
    end do
 ;*********************************************
     txres               = True
     txres@txFontHeightF = 0.017
     title = "IMPROVE "+season   
-    gsn_text_ndc(wks,title,.50,.85,txres)
+    gsn_text_ndc(wks,title,.45,.98,txres)
 
     panres = True
     panres@gsnFrame = False
@@ -536,10 +579,10 @@ res@trXAxisType = "LogAxis"
     panres@gsnPanelTop = 0.96
     if (time_stamp .eq. "True") then
       panres@gsnPanelBottom = 0.05
-      gsn_panel (wks,plot,(/2,3/),panres)
+      gsn_panel (wks,plot,(/2,2/),panres)
       infoTimeStamp(wks,0.011,"DIAG Version: "+version)
     else
-      gsn_panel (wks,plot,(/2,3/),panres)
+      gsn_panel (wks,plot,(/2,2/),panres)
     end if
     frame(wks)
     delete (title)

--- a/atm_diag/profiles_aircraft_noaa.ncl
+++ b/atm_diag/profiles_aircraft_noaa.ncl
@@ -216,7 +216,7 @@ do re = 0, nregions-1
    ; open obs data file
   if (vars(v).ne. "OH" .and. vars(v).ne."SAD_TROP" .and. vars(v).ne."CLOUD") then
 ;;    dir_in = "/glade/p/acd/tilmes/amwg/amwg_diag_20131004_work/obs_data/aircraft/"
-    dir_in = "$OBS_DATA/cam-chem/aircraft/NOAA/"
+    dir_in = "$OBS_DATA/cam-chem/"
     rin1 = addfile(dir_in+variablen(v)+aircraft(re1(re))+".nc","r")
     air1_med = rin1->prof_med
     air1_p25 = rin1->prof_p25

--- a/diagnostics/diagnostics/atm/model_vs_model.py
+++ b/diagnostics/diagnostics/atm/model_vs_model.py
@@ -235,6 +235,7 @@ class modelVsModel(AtmosphereDiagnostic):
                      glob_set = plot_set.replace('_','')
                      plot_set = 'set5_6'
                  elif 'set_1' == plot_set or 'cset_1' == plot_set:
+                     print('DEBUG model_vs_model: plot_set = %s' % plot_set)
                      glob_set = 'table_'
                      plot_set = plot_set.replace('_','') 
                  elif 'sets' == plot_set:

--- a/diagnostics/diagnostics/atm/model_vs_model.py
+++ b/diagnostics/diagnostics/atm/model_vs_model.py
@@ -230,31 +230,43 @@ class modelVsModel(AtmosphereDiagnostic):
           
             # Create set dirs, copy plots to set dir, and create html file for set 
             requested_plot_sets.append('sets') # Add 'sets' to create top level html files
+            glob_set = list()
             for plot_set in requested_plot_sets:
                  if 'set_5' == plot_set or 'set_6' == plot_set:
-                     glob_set = plot_set.replace('_','')
+                     glob_set.append(plot_set.replace('_',''))
                      plot_set = 'set5_6'
-                 elif 'set_1' == plot_set or 'cset_1' == plot_set:
-                     print('DEBUG model_vs_model: plot_set = %s' % plot_set)
-                     glob_set = 'table_'
-                     plot_set = plot_set.replace('_','') 
+                 elif 'cset_1' == plot_set:
+                     print('DEBUG model_vs_obs: plot_set = %s' % plot_set)
+                     glob_set.append('table_soa')
+                     glob_set.append('table_chem')                
+                     plot_set = plot_set.replace('_','')     
+                 elif 'set_1' == plot_set:
+                     print('DEBUG model_vs_obs: plot_set = %s' % plot_set)
+                     glob_set.append('table_GLBL')
+                     glob_set.append('table_NEXT')
+                     glob_set.append('table_SEXT')
+                     glob_set.append('table_TROP')
+                     plot_set = plot_set.replace('_','')
                  elif 'sets' == plot_set:
                      set_dir = web_dir + '/' 
                  else:
+                     glob_set.append(plot_set)
                      plot_set = plot_set.replace('_','')
-                     glob_set = plot_set
+
                  if 'sets' not in plot_set: #'sets' is top level, don't create directory or copy images files
                      set_dir = web_dir + '/' + plot_set
                      # Create the plot set web directory
                      if not os.path.exists(set_dir):
                          os.makedirs(set_dir) 
                      # Copy plots into the correct web dir
-                     glob_string = env['test_path_diag']+'/'+glob_set+'*.*'
-                     imgs = glob.glob(glob_string) 
-                     if imgs > 0:
-                         for img in imgs:
-                             new_fn = set_dir + '/' + os.path.basename(img)
-                             os.rename(img,new_fn)
+                     for gs in glob_set:
+                         glob_string = env['test_path_diag']+'/'+gs+'*.*'
+                         imgs = glob.glob(glob_string) 
+                         if imgs > 0:
+                             for img in imgs:
+                                 new_fn = set_dir + '/' + os.path.basename(img)
+                                 os.rename(img,new_fn)
+
                  # Copy/Process html files
                  if 'sets' in plot_set:
                      orig_html = env['HTML_HOME']+'/'+plot_set 

--- a/diagnostics/diagnostics/atm/model_vs_obs.py
+++ b/diagnostics/diagnostics/atm/model_vs_obs.py
@@ -228,6 +228,7 @@ class modelVsObs(AtmosphereDiagnostic):
                      glob_set = plot_set.replace('_','')
                      plot_set = 'set5_6'
                  elif 'set_1' == plot_set or 'cset_1' == plot_set:
+                     print('DEBUG model_vs_obs: plot_set = %s' % plot_set)
                      glob_set = 'table_'
                      plot_set = plot_set.replace('_','')
                  elif 'sets' == plot_set:

--- a/diagnostics/diagnostics/atm/model_vs_obs.py
+++ b/diagnostics/diagnostics/atm/model_vs_obs.py
@@ -223,31 +223,43 @@ class modelVsObs(AtmosphereDiagnostic):
 
             # Create set dirs, copy plots to set dir, and create html file for set 
             requested_plot_sets.append('sets') # Add 'sets' to create top level html files
+            glob_set = list()
             for plot_set in requested_plot_sets:
                  if 'set_5' == plot_set or 'set_6' == plot_set:
-                     glob_set = plot_set.replace('_','')
+                     glob_set.append(plot_set.replace('_',''))
                      plot_set = 'set5_6'
-                 elif 'set_1' == plot_set or 'cset_1' == plot_set:
+                 elif 'cset_1' == plot_set:
                      print('DEBUG model_vs_obs: plot_set = %s' % plot_set)
-                     glob_set = 'table_'
+                     glob_set.append('table_soa')                
+                     glob_set.append('table_chem')
+                     plot_set = plot_set.replace('_','')     
+                 elif 'set_1' == plot_set:
+                     print('DEBUG model_vs_obs: plot_set = %s' % plot_set)
+                     glob_set.append('table_GLBL')
+                     glob_set.append('table_NEXT')
+                     glob_set.append('table_SEXT')
+                     glob_set.append('table_TROP')
                      plot_set = plot_set.replace('_','')
                  elif 'sets' == plot_set:
                      set_dir = web_dir + '/'
                  else:
+                     glob_set.append(plot_set)
                      plot_set = plot_set.replace('_','')
-                     glob_set = plot_set
+
                  if 'sets' not in plot_set: #'sets' is top level, don't create directory or copy images files
                      set_dir = web_dir + '/' + plot_set
                      # Create the plot set web directory
                      if not os.path.exists(set_dir):
                          os.makedirs(set_dir)
                      # Copy plots into the correct web dir
-                     glob_string = env['test_path_diag']+'/'+glob_set+'*.*'
-                     imgs = glob.glob(glob_string)
-                     if imgs > 0:
-                         for img in imgs:
-                             new_fn = set_dir + '/' + os.path.basename(img)
-                             os.rename(img,new_fn)
+                     for gs in glob_set:
+                         glob_string = env['test_path_diag']+'/'+gs+'*.*'
+                         imgs = glob.glob(glob_string)
+                         if imgs > 0:
+                             for img in imgs:
+                                 new_fn = set_dir + '/' + os.path.basename(img)
+                                 os.rename(img,new_fn)
+
                  # Copy/Process html files
                  if 'sets' in plot_set:
                      orig_html = env['HTML_HOME']+'/'+plot_set

--- a/diagnostics/diagnostics/ocn/Plots/zonal_average_3d_fields.py
+++ b/diagnostics/diagnostics/ocn/Plots/zonal_average_3d_fields.py
@@ -75,6 +75,7 @@ class ZonalAverage3dFields(OceanDiagnosticPlot):
             # call ncks to extract the UAREA variable
             za_args = ['ncks','-A','-v','UAREA',env['TAVGFILE'],'{0}_tmp'.format(env['TOBSFILE']) ]
             if env['netcdf_format'] in ['netcdfLarge']:
+
                 za_args = ['ncks','-6','-A','-v','UAREA',env['TAVGFILE'],'{0}_tmp'.format(env['TOBSFILE']) ]
             try:
 ##                subprocess.check_output( ['ncks','-A','-v','UAREA',env['TAVGFILE'],'{0}_tmp'.format(env['TOBSFILE']) ], env=env)

--- a/ocn_diag/ncl_lib/field_3d_za.ncl
+++ b/ocn_diag/ncl_lib/field_3d_za.ncl
@@ -12,6 +12,14 @@ begin
   nlev    = 21
   missing = 1.0e30
 
+;; NOTE - for pop, the basin regions are always
+;; referenced by an index number, 1-14, with the
+;; region areas defined in the POP source code
+;; input_templates/[grid]_region_ids
+;; We are only interested in the regions listed
+;; below so want to subset the input fields 
+;; for just these basin index for these regions
+
   global   = 0
   atlantic = 6
   pacific  = 2 
@@ -65,7 +73,9 @@ begin
   do n=0,n_fields-1 
 
     fname = ListPop(field_name)
-    field = f_za->$fname$(0,:,:,:)
+;; just need the subset basin index of the second dimension
+;;    field = f_za->$fname$(0,:,:,:)
+    field = f_za->$fname$(0,0:6,:,:)
     field&z_t = z_t
     field@units = "km"
 
@@ -76,10 +86,11 @@ begin
       end if	
       field_obs = where(field_obs .lt. -50. .or. field_obs .gt. 1.e10,field_obs@_FillValue,field_obs)
       field_diff = field
+;; get just the basin index (region) in the first dimension
       if (isvar("ind_z_obs")) then
-        field_diff = field - field_obs(:,ind_z_obs,:)
+        field_diff = field - field_obs(0:6,ind_z_obs,:)
       else
-        field_diff = field - field_obs
+        field_diff = field - field_obs(0:6,:,:)
       end if
       units = "~S~o~N~C"
       dmin  =  -4.0
@@ -176,6 +187,7 @@ begin
         opt@do_panel = False
       end if
 
+;; field now has only 1 dimension 
       plot1 = yz_plot(wks,  field(region_index(m),:,:), lat_t, z_t, case_info, \
       missing, units, dlev, lev, coltab, opt)
 

--- a/ocn_diag/ncl_lib/field_3d_za.ncl
+++ b/ocn_diag/ncl_lib/field_3d_za.ncl
@@ -115,9 +115,10 @@ begin
       field_diff = field
       if (dimsizes(z_t) .ne. dimsizes(field_obs&$field_obs!1$)) then
         ind_z_obs = ind_nearest_coord(z_t*1000.,field_obs&$field_obs!1$,0)
-        field_diff = field - field_obs(:,ind_z_obs,:)
+;; only want the first 6 basin regions from the field_obs
+        field_diff = field - field_obs(0:6,ind_z_obs,:)
       else
-        field_diff = field - field_obs
+        field_diff = field - field_obs(0:6,:,:)
       end if	
 
       units = "psu"

--- a/ocn_diag/ncl_lib/field_3d_za_diff.ncl
+++ b/ocn_diag/ncl_lib/field_3d_za_diff.ncl
@@ -11,6 +11,14 @@ begin
   nlev    = 21
   missing = 1.0e30
 
+;; NOTE - for pop, the basin regions are always
+;; referenced by an index number, 1-14, with the
+;; region areas defined in the POP source code
+;; input_templates/[grid]_region_ids
+;; We are only interested in the regions listed
+;; below so want to subset the input fields 
+;; for just these basin index for these regions
+
   global   = 0
   atlantic = 6
   pacific  = 2 
@@ -63,16 +71,19 @@ begin
   coltab(1:) = ((color2-color1+1)/(nlev-1))*ispan(0,nlev-1,1)+color1
   coltab(0) = 0
 
+;; just need the subset basin index of the second dimension
   do n=0,n_fields-1 
 
     fname = ListPop(field_name)
     if (dimsizes(getfilevardimsizes(fileid_1,fname)) .eq. 4) then
-      field_1 = fileid_1->$fname$(0,:,:,:)
+;;      field_1 = fileid_1->$fname$(0,:,:,:)
+      field_1 = fileid_1->$fname$(0,0:6,:,:)
     else
       field_1 = fileid_1->$fname$(:,:,:)
     end if
     if (dimsizes(getfilevardimsizes(fileid_1,fname)) .eq. 4) then
-      field_2 = fileid_2->$fname$(0,:,:,:)
+;;      field_2 = fileid_2->$fname$(0,:,:,:)
+      field_2 = fileid_2->$fname$(0,0:6,:,:)
     else
       field_2 = fileid_2->$fname$(:,:,:)
     end if

--- a/timeseries/timeseries/cesm_tseries_generator.py
+++ b/timeseries/timeseries/cesm_tseries_generator.py
@@ -139,8 +139,8 @@ def readArchiveXML(caseroot, input_rootdir, output_rootdir, casename, standalone
                             raise TypeError(err_msg)
 
                         # load the tseries_time_variant_variables into a list
+                        variable_list = list()
                         if comp_archive_spec.find("tseries_time_variant_variables") is not None:
-                            variable_list = list()
                             for variable in comp_archive_spec.findall("tseries_time_variant_variables/variable"):
                                 variable_list.append(variable.text)
 

--- a/timeseries/timeseries/chunking.py
+++ b/timeseries/timeseries/chunking.py
@@ -5,6 +5,26 @@ import netCDF4 as nc
 import cf_units
 import datetime
 
+def num2date(time_value, unit, calendar):
+    if ('common_year' in unit):
+        my_unit = unit.replace('common_year', 'day')
+        my_time_value = time_value * 365
+    else:
+        my_unit = unit
+        my_time_value = time_value
+    return cf_units.num2date(my_time_value, my_unit, calendar)
+
+
+def date2num(date, unit, calendar):
+    if ('common_year' in unit):
+        my_unit = unit.replace('common_year', 'day')
+        my_conversion = 365.
+    else:
+        my_unit = unit
+        my_conversion = 1.
+    num = cf_units.date2num(date, my_unit, calendar)
+    return num/my_conversion
+
 def get_input_dates(glob_str):
 
     '''
@@ -96,11 +116,16 @@ def get_cesm_date(fn,t=None):
            l = len(f.variables[att['bounds']])
            d = (f.variables[att['bounds']][l-1][1])
     else:
-        d = f.variables['time'][1]    
-        
+        # problem if time has only one value when units are common_year
+        try:
+            d = f.variables['time'][1]    
+        except:
+            d = f.variables['time'][0]    
+
     print 'after d = ',d
 
-    d1 = cf_units.num2date(d,att['units'],att['calendar'].lower())
+##    d1 = cf_units.num2date(d,att['units'],att['calendar'].lower())
+    d1 = num2date(d,att['units'],att['calendar'].lower())
 
     print 'd1.year = ',str(d1.year).zfill(4)
     print 'd1.month = ',str(d1.month).zfill(2)
@@ -128,7 +153,8 @@ def get_chunk_range(tper, size, start, cal, units):
     '''
 
     # Get the first date
-    d1 = cf_units.num2date(start, units, cal)
+##    d1 = cf_units.num2date(start, units, cal)
+    d1 = num2date(start, units, cal)
 
     # Figure out how many days each chunk should be
     if 'day' in tper: #day
@@ -144,11 +170,13 @@ def get_chunk_range(tper, size, start, cal, units):
             y2 = y2 + 1
             m2 = m2 - 12
         d2 = datetime.datetime(y2, m2, d1.day, d1.hour, d1.minute)
-        end = cf_units.date2num(d2, units, cal)
+##        end = cf_units.date2num(d2, units, cal)
+        end = date2num(d2, units, cal)
 
     elif 'year' in tper: #year
         d2 = datetime.datetime(int(size)+d1.year, d1.month, d1.day, d1.hour, d1.minute)
-        end = cf_units.date2num(d2, units, cal)
+##        end = cf_units.date2num(d2, units, cal)
+        end = date2num(d2, units, cal)
 
     return start, end 
 


### PR DESCRIPTION
- Fix CISM timeseries generation using a couple of wrapper methods in chunking.py to get
around problems with cf_units and time attribute = "common_year since...". Tested with 
44 years of CISM data from PI Control run 136
- Fix atm diags copy of cset1 and set1 tables to the correct diagnostics subdirectories
- Fix ocn diags NCL field_3d_za.ncl and field_3d_za_diff.ncl files to only look at basin regions
indexed from 0:6 in both the model and obs files. This fixes the problem related to the removal
of the Caspian Sea as a basin region (index 14) and comparison with obs and older pop data.