### PR TITLE
bug fixes and enhancements

### DIFF
--- a/Tools/count_tseries_vars.py
+++ b/Tools/count_tseries_vars.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+
+import os, string
+
+file = open('time_series_vars.txt','r')
+buffer = file.read()
+tseries = buffer.split('\n')
+tseries.pop()
+for stream in tseries:
+    stream.replace('  Time-Series Variables: ','')
+    stream.replace('[','')
+    stream.replace(']','')
+    vars = stream.split(',')
+    print len(vars)


### PR DESCRIPTION
- bug fix to chunking for CISM time_value floats causing a cf_units to fail with an out-of-date
- add option TIMESERIES_GENERATE_ALL to env_postprocess to override the tseries_create 
element settings in the env_timeseries.xml so that all available history slice streams are converted
to variable timeseries files. 
- set the MODEL_VS_CONTROL=FALSE as the default for env_diags_ocn.xml

Tested with default cylc suite settings from CESM-WF repo and variable timeseries generation
for the b.e20.BHIST.20thC.144_01 data output. 