### PR TITLE
bug fixes for timeseries

### DIFF
--- a/Config/config_timeseries.xml
+++ b/Config/config_timeseries.xml
@@ -312,6 +312,14 @@
         <tseries_filecat_tper>years</tseries_filecat_tper>
         <tseries_filecat_n>10</tseries_filecat_n>
       </file_extension>
+      <file_extension suffix=".h1.[0-9]">      
+	<subdir>hist</subdir> 
+	<tseries_create>FALSE</tseries_create>
+	<tseries_output_format>netcdf4c</tseries_output_format>
+	<tseries_tper>day_1</tseries_tper>
+        <tseries_filecat_tper>years</tseries_filecat_tper>
+        <tseries_filecat_n>10</tseries_filecat_n>
+      </file_extension>
     </files>
     <tseries_time_variant_variables>
       <variable>time</variable>
@@ -391,6 +399,14 @@
 	<tseries_tper>year_1</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
         <tseries_filecat_n>100</tseries_filecat_n>
+      </file_extension>
+      <file_extension suffix=".h1.[0-9]">      
+	<subdir>hist</subdir> 
+	<tseries_create>FALSE</tseries_create>
+	<tseries_output_format>netcdf4c</tseries_output_format>
+	<tseries_tper>month_1</tseries_tper>
+        <tseries_filecat_tper>years</tseries_filecat_tper>
+        <tseries_filecat_n>10</tseries_filecat_n>
       </file_extension>
     </files>
     <tseries_time_variant_variables>

--- a/Templates/batch_cheyenne.tmpl
+++ b/Templates/batch_cheyenne.tmpl
@@ -41,3 +41,4 @@
 . /glade/u/apps/ch/opt/lmod/7.2.1/lmod/lmod/init/bash
 
 export I_MPI_DEVICE=rdma
+export MPI_UNBUFFERED_STDIO=true

--- a/Templates/postprocess.tmpl
+++ b/Templates/postprocess.tmpl
@@ -32,14 +32,16 @@ PYTHONPATH={{ pythonpath }}:$PYTHONPATH
 export PYTHONPATH
 {% endif %}
 
+today="$(date '+%Y%m%d-%H%M%S')"
+
 echo "******************************************"
 echo "Start {{ processName }} generation $(date)"
 echo "******************************************"
 
 {% if standalone %}
-{{ mpirun|replace("{{ pes }}",pes) }} ./{{ postProcessCmd }} {{ debug }} {{ backtrace }} --caseroot {{ caseRoot }} --standalone >> {{ caseRoot }}/logs/{{ processName }}.log 2>&1
+{{ mpirun|replace("{{ pes }}",pes) }} ./{{ postProcessCmd }} {{ debug }} {{ backtrace }} --caseroot {{ caseRoot }} --standalone >> {{ caseRoot }}/logs/{{ processName }}.log.$today 2>&1
 {% else %}
-{{ mpirun|replace("{{ pes }}",pes) }} ./{{ postProcessCmd }} {{ debug }} {{ backtrace }} --caseroot {{ caseRoot }} >> {{ caseRoot }}/logs/{{ processName }}.log 2>&1
+{{ mpirun|replace("{{ pes }}",pes) }} ./{{ postProcessCmd }} {{ debug }} {{ backtrace }} --caseroot {{ caseRoot }} >> {{ caseRoot }}/logs/{{ processName }}.log.$today 2>&1
 {% endif %}
 
 echo "******************************************"

--- a/ocn_diag/tool_lib/zon_avg/makefile
+++ b/ocn_diag/tool_lib/zon_avg/makefile
@@ -4,8 +4,8 @@
 
 FC = ifort
 FFLAGS = -c -g -O2
-INCLUDE = -I/glade/u/apps/ch/opt/netcdf/4.4.1.1/intel/16.0.3/include
-LIBS = -L/glade/u/apps/ch/opt/netcdf/4.4.1.1/intel/16.0.3/lib -lnetcdff -lnetcdf
+INCLUDE = -I/glade/apps/opt/netcdf/4.2/intel/12.1.5/include
+LIBS = -L/glade/apps/opt/netcdf/4.2/intel/12.1.5/lib -lnetcdff -lnetcdf
 
 .SUFFIXES:            # Delete the default suffixes
 .SUFFIXES: .F .F90 .o # Define our suffix list

--- a/timeseries/timeseries/chunking.py
+++ b/timeseries/timeseries/chunking.py
@@ -81,6 +81,7 @@ def get_input_dates(glob_str):
             except:
                 print 'Global attribute time_period_freq not found - set to XML tseries_tper element'
             first = False
+        f.close()
 
     return stream_dates,file_slices,att['calendar'].lower(),att['units'],time_period_freq
 
@@ -287,8 +288,9 @@ def write_log(log_fn, log):
     log(dictionary) - keys->file streams, values->the dates that have been 
                          converted and next indexes to use for size and tper lists 
     '''
-    with open(log_fn, 'w') as f:
+    with open(log_fn, 'a+') as f:
         json.dump(log, f)
+    f.close()
 
 
 def read_log(log_fn):
@@ -307,6 +309,7 @@ def read_log(log_fn):
     if os.path.isfile(log_fn):
         with open(log_fn, 'r') as f:
             d = json.load(f)
+        f.close()
         return d
     else:
         return {}


### PR DESCRIPTION
add more file streams for timeseries; 
fix memory leak in chunking; 
append to ts_status.log and add datetime stamp to the end of log filenames

Test - generated variable timeseries for CISM and MOSART files from run
b.e20.BHIST.f09_g17.20thC.179_03

Fixes issues #85 and #86. 