### PR TITLE
bug fix to parallel timeseries chunking

### DIFF
--- a/timeseries/timeseries/cesm_tseries_generator.py
+++ b/timeseries/timeseries/cesm_tseries_generator.py
@@ -184,8 +184,10 @@ def readArchiveXML(caseroot, input_rootdir, output_rootdir, casename, standalone
                         log[comp+stream]['index']=index
                         for cn,cf in files.iteritems():
 
-                            if not os.path.exists(tseries_output_dir):
-                                os.makedirs(tseries_output_dir)
+                            if rank == 0:
+                                if not os.path.exists(tseries_output_dir):
+                                    os.makedirs(tseries_output_dir)
+                            comm.sync()
 
                             history_files = cf['fn']
                             start_time_parts = cf['start']


### PR DESCRIPTION
minor problem fix for parallel chunking where directory creation needed
to be done on rank 0. 

Tested with 5 years or day_5 (cam.h7) history data, 2 year chunks, 
with complete_chunk = false. 