### PR TITLE
Iomb and ilamb integration fix for cheyenne

### DIFF
--- a/Machines/machine_postprocess.xml
+++ b/Machines/machine_postprocess.xml
@@ -128,6 +128,19 @@
 	<diagnostics_pes queue="regular" nodes="1" pes_per_node="36" wallclock="01:00:00">36</diagnostics_pes>
 	<obs_root>/glade/p/cesm/</obs_root>
       </component>
+      <component name="ilamb">
+	<averages_pes queue="regular" nodes="0" pes_per_node="0" wallclock="00:01">0</averages_pes> <!-- unsued. not required by xsd but required by the code. -->
+	<diagnostics_pes queue="regular" nodes="1" pes_per_node="36" wallclock="01:00">36</diagnostics_pes>
+	<initialize_pes queue="share" nodes="1" pes_per_node="36" wallclock="00:10">1</initialize_pes>
+	<obs_root>/glade/p/cesm/lmwg_dev/oleson/ILAMB/ILAMB_all</obs_root>
+      </component>
+      <component name="iomb">
+	<averages_pes queue="regular" nodes="0" pes_per_node="0" wallclock="00:01">0</averages_pes> <!-- unsued. not required by xsd but required by the code. -->
+	<diagnostics_pes queue="regular" nodes="1" pes_per_node="36" wallclock="01:00">36</diagnostics_pes>
+	<initialize_pes queue="share" nodes="1" pes_per_node="36" wallclock="00:10">1</initialize_pes>
+	<obs_root>/glade/p/cesm/omwg/obs_data/IOMB</obs_root>
+      </component>
+
     </components>
   </machine>
 

--- a/Machines/machine_postprocess.xml
+++ b/Machines/machine_postprocess.xml
@@ -66,7 +66,7 @@
 	<averages_pes queue="regular" pes_per_node="0" wallclock="00:01">0</averages_pes> <!-- unsued. not required by xsd but required by the code. -->
 	<diagnostics_pes queue="geyser" pes_per_node="2" wallclock="01:00">2</diagnostics_pes>
 	<initialize_pes queue="geyser" pes_per_node="1" wallclock="00:10">1</initialize_pes>
-	<obs_root>/glade/p/cesm/omwg/obs_data/IOMB/IOMB_all</obs_root>
+	<obs_root>/glade/p/cesm/omwg/obs_data/IOMB</obs_root>
       </component>
     </components>
   </machine>

--- a/Machines/machine_postprocess.xml
+++ b/Machines/machine_postprocess.xml
@@ -62,6 +62,12 @@
 	<initialize_pes queue="geyser" pes_per_node="1" wallclock="00:10">1</initialize_pes>
 	<obs_root>/glade/p/cesm/lmwg_dev/oleson/ILAMB/ILAMB_all</obs_root>
       </component>
+      <component name="iomb">
+	<averages_pes queue="regular" pes_per_node="0" wallclock="00:01">0</averages_pes> <!-- unsued. not required by xsd but required by the code. -->
+	<diagnostics_pes queue="geyser" pes_per_node="2" wallclock="01:00">2</diagnostics_pes>
+	<initialize_pes queue="geyser" pes_per_node="1" wallclock="00:10">1</initialize_pes>
+	<obs_root>/glade/p/cesm/omwg/obs_data/IOMB/IOMB_all</obs_root>
+      </component>
     </components>
   </machine>
 

--- a/Tools/link_history_files.py
+++ b/Tools/link_history_files.py
@@ -29,15 +29,28 @@ import os
 ##        filename = '{0}.{1}-{2}-01.nc'.format(casename,year,month)
 ##        os.symlink(os.path.join(srcdir, filename), os.path.join(linkdir, filename))
 
-for year in ['1960','1961','1962','1963','1964','1965','1966','1967','1968','1969']:
+for year in ['0101','0102','0103','0104','0105','0106','0107','0108','0109','0110','0111','0112','0113','0114','0115','0116','0117','0118','0119','0120']:
     for month in ['01','02','03','04','05','06','07','08','09','10','11','12']:
         
-        srcdir = '/glade/p/cesm0005/archive/b.e20.BHIST.f09_g17.20thC.192_01/ocn/hist'
-        linkdir = '/glade/scratch/aliceb/b.e20.BHIST.f09_g17.20thC.192_01/ocn/hist'
+        srcdir = '/glade/p/cesm0005/archive/b.e20.B1850.f09_g17.pi_control.all.197/ocn/hist'
+        linkdir = '/glade/scratch/aliceb/b.e20.B1850.f09_g17.pi_control.all.197/ocn/hist'
 
         if not os.path.exists(linkdir):
             os.makedirs(linkdir)
 
-        casename = 'b.e20.BHIST.f09_g17.20thC.192_01.pop.h'
+        casename = 'b.e20.B1850.f09_g17.pi_control.all.197.pop.h'
+        filename = '{0}.{1}-{2}.nc'.format(casename,year,month)
+        os.symlink(os.path.join(srcdir, filename), os.path.join(linkdir, filename))
+
+for year in ['0101','0102','0103','0104','0105','0106','0107','0108','0109','0110','0111','0112','0113','0114','0115','0116','0117','0118','0119','0120']:
+    for month in ['01','02','03','04','05','06','07','08','09','10','11','12']:
+        
+        srcdir = '/glade/p/cesm0005/archive/b.e20.B1850.f09_g17.pi_control.all.201/ocn/hist'
+        linkdir = '/glade/scratch/aliceb/b.e20.B1850.f09_g17.pi_control.all.201/ocn/hist'
+
+        if not os.path.exists(linkdir):
+            os.makedirs(linkdir)
+
+        casename = 'b.e20.B1850.f09_g17.pi_control.all.201.pop.h'
         filename = '{0}.{1}-{2}.nc'.format(casename,year,month)
         os.symlink(os.path.join(srcdir, filename), os.path.join(linkdir, filename))

--- a/cesm_utils/cesm_utils/create_postprocess
+++ b/cesm_utils/cesm_utils/create_postprocess
@@ -621,7 +621,7 @@ def main(options):
     compList = ['atm','ice','lnd','ocn']
     regridList = ['atm','lnd']
     regridList = ['lnd']
-    imbList = ['ilamb', ]
+    imbList = ['ilamb', 'iomb']
 
     # get the machine dependent variables, modules and mpi run command in a dictionary
     machine = dict()

--- a/diagnostics/diagnostics/imb/Config/config_diags_iomb.xml
+++ b/diagnostics/diagnostics/imb/Config/config_diags_iomb.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0"?>
+
+<!-- =========================================================================== -->
+<!-- ILAMB Wrapper XML                                                           -->
+<!-- =========================================================================== -->
+
+<config_definition version="1.0">
+
+  <!-- =========================================================================== -->
+  <!-- iomb_settings - general settings to be applied to all diagnostics routines   -->
+  <!-- NOTE: case specific environment variables from env_*.xml will be            -->
+  <!-- gathered at runtime by the iomb_diags_generator.py python script.            -->
+  <!-- They do not need to be specified in this XML file.                          -->
+  <!-- The full $PATH variable will be set in the iomb_diags_generator.py file      -->
+  <!-- using all the path settings defined here.                                   -->
+  <!-- =========================================================================== -->
+
+  <groups>
+    
+    <group name="global">
+      <order>0</order>
+      <comment>Run provenance</comment>
+
+      <entry id="IOMBDIAG_VERSION"
+             type="char"
+             valid_values=""
+             value="iomb_version"
+             group="diags_iomb"
+             desc="Package Version"
+             ></entry>
+
+    </group>
+    
+    <group name="iomb_env">
+      <order>1</order>
+      <comment>IOMB Environment Variables, must be exported prior to executing imb_run</comment>
+
+      <entry id="IOMBDIAG_MPLBACKEND"
+             type="char"
+             valid_values="Agg"
+             value="Agg"
+             group="iomb_env"
+             desc="matplotlib backend for generating graphics, should be exported to the environment!"
+             ></entry>
+
+      <entry id="IOMBDIAG_IOMB_ROOT"
+             type="char"
+             valid_values="/path/to/IOMB_ROOT"
+             value="$IOMBDIAG_DIAGOBSROOT"
+             group="iomb_env"
+             desc="Environment variable for the model data root path. These are data files downloaded using the ilamb-fetch command. NOTE: this is machine and / or user dependent."
+             ></entry>
+    </group>
+
+    <group name="iomb_config">
+      <order>2</order>
+      <comment>IOMB Configuration Options</comment>
+
+      <entry id="IOMBDIAG_CONFIG_TYPE"
+             type="char"
+             valid_values="standard"
+             value="standard"
+             group="iomb_config"
+             desc="whether to use a standard or templated configuration file. NOTE: Templated is not implemented at this time."
+             ></entry>
+
+      <entry id="IOMBDIAG_CONFIG_DIRECTORY"
+             type="char"
+             value="$POSTPROCESS_PATH/diagnostics/diagnostics/imb/Config/"
+             group="iomb_config"
+             desc="name of the directory containing the standard or template configuration file"
+             ></entry>
+
+      <entry id="IOMBDIAG_CONFIG_NAME"
+             type="char"
+             value="iomb-sample.cfg"
+             group="iomb_config"
+             desc="name of the standard or template filename to use"
+             ></entry>
+
+    </group>
+
+
+    <group name="iomb_cli">
+      <order>3</order>
+      <comment>IOMB Command-line Interface Options</comment>
+
+      <entry id="IOMBDIAG_EXENAME"
+             type="char"
+             valid_values="ilamb-run"
+             value="ilamb-run"
+             group="iomb_cli"
+             desc="imb diagnostics executable name. Must be an absolute path or available in the virtualenv or in the users path."
+             ></entry>
+
+      <entry id="IOMBDIAG_MODELROOT"
+             type="char"
+             valid_values="/path/to/model/root"
+             value="$IOMBDIAG_DIAGOBSROOT/MODELS"
+             group="iomb_config"
+             desc="root directory containing the model data"
+             ></entry>
+
+      <entry id="IOMBDIAG_OUTPUTROOT"
+             type="char"
+             valid_values="/path/to/model/output/root"
+             value="$DOUT_S_ROOT/ocn/proc/iomb"
+             group="iomb_config"
+             desc="output root directory containing the html and diagnostics plots"
+             ></entry>
+
+      <entry id="IOMBDIAG_MODELNAME"
+             type="char"
+             valid_values=""
+             value="CLM50r243GSWP3"
+             group="iomb_config"
+             desc="model directory name"
+             ></entry>
+
+      <entry id="IOMBDIAG_CLI_REQUIRED"
+             type="char"
+             value=" --config $CASEROOT/$IOMBDIAG_CONFIG_NAME --model_root $IOMBDIAG_MODELROOT/  --models $IOMBDIAG_MODELNAME --build_dir $IOMBDIAG_OUTPUTROOT"
+             group="iomb_cli"
+             desc="required command line options passed to IOMBDIAG_EXENAME"
+             ></entry>
+
+      <entry id="IOMBDIAG_CLI_OPTIONAL"
+             type="char"
+             valid_values=""
+             value="--regions global --filter _historical_ --disable_logging"
+             group="iomb_cli"
+             desc="optional command line options passed to IOMBDIAG_EXENAME"
+             ></entry>
+
+      <entry id="IOMBDIAG_CLI"
+             type="char"
+             value="$IOMBDIAG_CLI_REQUIRED $IOMBDIAG_CLI_OPTIONAL"
+             group="iomb_cli"
+             desc="Complete list of command line options to pass to IOMBDIAG_EXENAME"
+             ></entry>
+
+    </group>
+
+  </groups>
+</config_definition>
+

--- a/diagnostics/diagnostics/imb/Config/iomb-sample.cfg
+++ b/diagnostics/diagnostics/imb/Config/iomb-sample.cfg
@@ -1,0 +1,65 @@
+# This configure file uses observational data which can be obtained by
+# running the following command after exporting ILAMB_ROOT to the
+# appropriate location.
+#
+#   ilamb-fetch --remote_root http://ilamb.ornl.gov/IOMB-Data
+#
+[h1: Marine Chemistry]
+bgcolor = "#ECFFE6"
+
+[h2: Nitrate]
+variable       = "no3"
+alternate_vars = "NO3"
+cmap           = "PuBu"
+ctype          = "ConfIOMB"
+
+[WOA] 
+source        = "DATA/nitrate/WOA/nitrate.nc"
+
+[h2: Phosphate]
+variable       = "po4"
+alternate_vars = "PO4"
+cmap           = "Oranges"
+ctype          = "ConfIOMB"
+
+[WOA] 
+source        = "DATA/phosphate/WOA/phosphate.nc"
+
+[h2: Silicate]
+variable       = "si"
+alternate_vars = "SiO3"
+cmap           = "BuPu"
+ctype          = "ConfIOMB"
+
+[WOA] 
+source        = "DATA/silicate/WOA/silicate.nc"
+
+[h1: Physical Quantities]
+bgcolor = "#FFECE6"
+
+[h2: Salinity]
+variable       = "so"
+alternate_vars = "SALT"
+cmap           = "GnBu"
+ctype          = "ConfIOMB"
+
+[WOA] 
+source        = "DATA/salinity/WOA/salinity.nc"
+
+[h2: Oxygen]
+variable       = "o2"
+alternate_vars = "O2"
+cmap           = "GnBu"
+ctype          = "ConfIOMB"
+
+[WOA] 
+source        = "DATA/oxygen/WOA/oxygen.nc"
+
+[h2: Temperature]
+variable       = "thetao"
+alternate_vars = "TEMP"
+cmap           = "rainbow"
+ctype          = "ConfIOMB"
+
+[WOA] 
+source        = "DATA/temperature/WOA/temperature.nc"


### PR DESCRIPTION
add XML definitions to support ilamb and iomb integration on cheyenne. 
Change required because create_postprocess is failing on cheyenne without
these definitions. 