### PR TITLE
minor fix to create_ocn_za script

### DIFF
--- a/cesm_utils/cesm_utils/create_ocn_za
+++ b/cesm_utils/cesm_utils/create_ocn_za
@@ -167,9 +167,8 @@ def main(options):
     # remove the existing makefile if it exists
     try:
         os.remove(outFile)
-    except OSError as e:
-        print('ERROR create_ocn_za',e.errno,e.strerror)
-        sys.exit(1)
+    except OSError:
+        pass
 
     # write the makefile to the outFile
     with open( outFile, 'w') as fh:


### PR DESCRIPTION
create_ocn_za creates a machine dependent makefile with instructions on how to
compile the ocean zonal average tool, za. This fix removes an existing makefile,
if it exists, prior to creating the new makefile as part of create_python_env. 