### PR TITLE
add LD_LIBRARY_PATH to batch_geyser.tmpl

### DIFF
--- a/Machines/geyser_modules
+++ b/Machines/geyser_modules
@@ -12,7 +12,7 @@ module load mpi4py/2.0.0
 module load pynio/1.4.1
 module load pyside/1.1.2
 module load matplotlib/1.5.1
-module load intel/12.1.5
+module load gnu/6.1.0
 module load netcdf/4.3.0
 module load nco/4.4.4
 module load ncl/6.4.0

--- a/Machines/machine_postprocess.xml
+++ b/Machines/machine_postprocess.xml
@@ -10,10 +10,10 @@
     <pythonpath>/glade/apps/opt/python/2.7.7/gnu-westmere/4.8.2/lib/python2.7/site-packages</pythonpath>
     <f2py fcompiler="gfortran" f77exec="/usr/bin/gfortran">f2py</f2py>
     <za>
-      <compiler>ifort</compiler>
+      <compiler>gfortran</compiler>
       <flags>-c -g -O2</flags>
-      <include>-I/glade/apps/opt/netcdf/4.3.0/intel/12.1.5/include</include>
-      <libs>-L/glade/apps/opt/netcdf/4.3.0/intel/12.1.5/lib -lnetcdff -lnetcdf</libs>
+      <include>-I/glade/apps/opt/netcdf/4.3.0/gnu/default/include</include>
+      <libs>-L/glade/apps/opt/netcdf/4.3.0/gnu/default/lib -lnetcdff -lnetcdf</libs>
     </za>
     <reset_modules>
       <module>module purge</module>

--- a/Templates/batch_geyser.tmpl
+++ b/Templates/batch_geyser.tmpl
@@ -12,3 +12,4 @@
 
 source /glade/u/apps/opt/slurm_init/init.sh
 
+export LD_LIBRARY_PATH=/glade/apps/opt/netcdf/4.3.0/gnu/default/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
There was a problem with the ocean za tool not being able to find the libnetcdff.so.5 library
as it now requires that the za tool be compiled with gnu fortran rather than intel due
to the constraint of the gnu build of slurm. 

This PR adds a LD_LIBRARY_PATH variable to the batch_geyser.tmpl template file. 

Tested with 6 years of ocean data and the ocn_diagnostics_geyser batch submission script. 
