### PR TITLE
fix for ocn_diagnostics_geyser

### DIFF
--- a/Config/config_timeseries.xml
+++ b/Config/config_timeseries.xml
@@ -44,7 +44,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>month_1</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>10</tseries_filecat_n>
+        <tseries_filecat_n>1000</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h1.[0-9]">      
 	<subdir>hist</subdir> 
@@ -52,7 +52,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>day_1</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>5</tseries_filecat_n>
+        <tseries_filecat_n>100</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h2.[0-9]">      
 	<subdir>hist</subdir> 
@@ -60,7 +60,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>hour_6</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>1</tseries_filecat_n>
+        <tseries_filecat_n>100</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h3.[0-9]">      
 	<subdir>hist</subdir> 
@@ -68,7 +68,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>hour_3</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>1</tseries_filecat_n>
+        <tseries_filecat_n>100</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h4.[0-9]">      
 	<subdir>hist</subdir> 
@@ -76,7 +76,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>hour_1</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>1</tseries_filecat_n>
+        <tseries_filecat_n>100</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h5.[0-9]">      
 	<subdir>hist</subdir> 
@@ -84,7 +84,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>min_30</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>1</tseries_filecat_n>
+        <tseries_filecat_n>100</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h6.[0-9]">      
 	<subdir>hist</subdir> 
@@ -92,7 +92,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>day_1</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>1</tseries_filecat_n>
+        <tseries_filecat_n>100</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h7.[0-9]">      
 	<subdir>hist</subdir> 
@@ -100,7 +100,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>day_5</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>1</tseries_filecat_n>
+        <tseries_filecat_n>100</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h8.[0-9]">      
 	<subdir>hist</subdir> 
@@ -108,7 +108,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>undefined</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>10</tseries_filecat_n>
+        <tseries_filecat_n>100</tseries_filecat_n>
       </file_extension>
     </files>
     <tseries_time_variant_variables>
@@ -141,7 +141,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>month_1</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>10</tseries_filecat_n>
+        <tseries_filecat_n>1000</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h1.[0-9]">      
 	<subdir>hist</subdir> 
@@ -149,7 +149,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>day_1</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>5</tseries_filecat_n>
+        <tseries_filecat_n>100</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h2.[0-9]">      
 	<subdir>hist</subdir> 
@@ -157,7 +157,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>hour_6</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>1</tseries_filecat_n>
+        <tseries_filecat_n>100</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h3.[0-9]">      
 	<subdir>hist</subdir> 
@@ -165,7 +165,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>hour_3</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>1</tseries_filecat_n>
+        <tseries_filecat_n>100</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h4.[0-9]">      
 	<subdir>hist</subdir> 
@@ -173,7 +173,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>hour_1</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>1</tseries_filecat_n>
+        <tseries_filecat_n>100</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h5.[0-9]">      
 	<subdir>hist</subdir> 
@@ -181,7 +181,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>min_30</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>1</tseries_filecat_n>
+        <tseries_filecat_n>100</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h6.[0-9]">      
 	<subdir>hist</subdir> 
@@ -189,7 +189,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>day_1</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>1</tseries_filecat_n>
+        <tseries_filecat_n>100</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h7.[0-9]">      
 	<subdir>hist</subdir> 
@@ -197,7 +197,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>hour_1</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>1</tseries_filecat_n>
+        <tseries_filecat_n>100</tseries_filecat_n>
       </file_extension>
     </files>
     <tseries_time_variant_variables>
@@ -224,7 +224,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>month_1</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>10</tseries_filecat_n>
+        <tseries_filecat_n>1000</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h1.[0-9]">      
 	<subdir>hist</subdir> 
@@ -232,7 +232,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>day_1</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>5</tseries_filecat_n>
+        <tseries_filecat_n>100</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h2.[0-9]">      
 	<subdir>hist</subdir> 
@@ -240,7 +240,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>hour_6</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>1</tseries_filecat_n>
+        <tseries_filecat_n>100</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h3.[0-9]">      
 	<subdir>hist</subdir> 
@@ -248,7 +248,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>hour_3</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>1</tseries_filecat_n>
+        <tseries_filecat_n>100</tseries_filecat_n>
       </file_extension>
     </files>
     <tseries_time_variant_variables>
@@ -275,7 +275,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>month_1</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>10</tseries_filecat_n>
+        <tseries_filecat_n>1000</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h1.[0-9]">      
 	<subdir>hist</subdir> 
@@ -283,7 +283,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>day_1</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>5</tseries_filecat_n>
+        <tseries_filecat_n>100</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h2.[0-9]">      
 	<subdir>hist</subdir> 
@@ -291,7 +291,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>hour_6</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>1</tseries_filecat_n>
+        <tseries_filecat_n>100</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h3.[0-9]">      
 	<subdir>hist</subdir> 
@@ -299,7 +299,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>hour_3</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>1</tseries_filecat_n>
+        <tseries_filecat_n>100</tseries_filecat_n>
       </file_extension>
     </files>
     <tseries_time_variant_variables>
@@ -326,7 +326,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>month_1</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>10</tseries_filecat_n>
+        <tseries_filecat_n>1000</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h1.[0-9]">      
 	<subdir>hist</subdir> 
@@ -334,7 +334,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>day_1</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>10</tseries_filecat_n>
+        <tseries_filecat_n>100</tseries_filecat_n>
       </file_extension>
     </files>
     <tseries_time_variant_variables>
@@ -354,7 +354,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>month_1</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>10</tseries_filecat_n>
+        <tseries_filecat_n>1000</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h.nday1.[0-9]">      
 	<subdir>hist</subdir> 
@@ -362,7 +362,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>day_1</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>5</tseries_filecat_n>
+        <tseries_filecat_n>100</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h.nyear1.[0-9]">      
 	<subdir>hist</subdir> 
@@ -370,7 +370,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>year_1</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>10</tseries_filecat_n>
+        <tseries_filecat_n>100</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h.ecosys.[0-9]">      
 	<subdir>hist</subdir> 
@@ -378,7 +378,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>month_1</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>10</tseries_filecat_n>
+        <tseries_filecat_n>1000</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h.ecosys.nyear1.[0-9]">      
 	<subdir>hist</subdir> 
@@ -386,7 +386,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>year_1</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>10</tseries_filecat_n>
+        <tseries_filecat_n>1000</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h.ecosys.nday1.[0-9]">      
 	<subdir>hist</subdir> 
@@ -394,7 +394,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>day_1</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>5</tseries_filecat_n>
+        <tseries_filecat_n>100</tseries_filecat_n>
       </file_extension>
     </files>
     <tseries_time_variant_variables>
@@ -414,7 +414,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>year_1</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>100</tseries_filecat_n>
+        <tseries_filecat_n>1000</tseries_filecat_n>
       </file_extension>
       <file_extension suffix=".h1.[0-9]">      
 	<subdir>hist</subdir> 
@@ -422,7 +422,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>month_1</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>10</tseries_filecat_n>
+        <tseries_filecat_n>1000</tseries_filecat_n>
       </file_extension>
     </files>
     <tseries_time_variant_variables>
@@ -441,7 +441,7 @@
 	<tseries_output_format>netcdf4c</tseries_output_format>
 	<tseries_tper>month_1</tseries_tper>
         <tseries_filecat_tper>years</tseries_filecat_tper>
-        <tseries_filecat_n>10</tseries_filecat_n>
+        <tseries_filecat_n>1000</tseries_filecat_n>
       </file_extension>
     </files>
   </comp_archive_spec>

--- a/Machines/geyser_modules
+++ b/Machines/geyser_modules
@@ -3,16 +3,17 @@
 echo "Python boot-strap modules for machine geyser"
 . /glade/apps/opt/lmod/lmod/init/bash
 
-module unload all-python-libs
-
 module load python/2.7.7
+module load gnu/6.1.0
+module load ncarenv
+module load ncarbinlibs
+module load ncarcompilers
 module load numpy/1.11.0
 module load scipy/0.18.1
 module load mpi4py/2.0.0
 module load pynio/1.4.1
 module load pyside/1.1.2
 module load matplotlib/1.5.1
-module load gnu/6.1.0
 module load netcdf/4.3.0
 module load nco/4.4.4
 module load ncl/6.4.0

--- a/Machines/geyser_modules
+++ b/Machines/geyser_modules
@@ -8,6 +8,8 @@ module load gnu/6.1.0
 module load ncarenv
 module load ncarbinlibs
 module load ncarcompilers
+module load slurm/17
+module load openmpi-slurm/3.0.0
 module load numpy/1.11.0
 module load scipy/0.18.1
 module load mpi4py/2.0.0

--- a/Machines/machine_postprocess.xml
+++ b/Machines/machine_postprocess.xml
@@ -3,9 +3,8 @@
 <machine_postprocess>
 
   <machine name="geyser" hostname="geyser">
-    <!-- restricting to geyser for CMIP6 and problem with scaling of the chunking -->
-    <timeseries_pes queue="geyser" nodes="1" pes_per_node="32" wallclock="04:00:00" memory="900G">32</timeseries_pes>
-    <xconform_pes queue="geyser" nodes="1" pes_per_node="32" wallclock="06:00:00" memory="900G">32</xconform_pes>
+    <timeseries_pes queue="geyser" nodes="4" pes_per_node="16" wallclock="04:00:00" memory="100G">64</timeseries_pes>
+    <xconform_pes queue="geyser" nodes="4" pes_per_node="16" wallclock="06:00:00" memory="100G">64</xconform_pes>
     <mpi_command>mpiexec</mpi_command>
     <pythonpath>/glade/apps/opt/python/2.7.7/gnu-westmere/4.8.2/lib/python2.7/site-packages</pythonpath>
     <f2py fcompiler="gfortran" f77exec="/usr/bin/gfortran">f2py</f2py>
@@ -21,6 +20,10 @@
     </reset_modules>
     <modules>
       <module>module load gnu/6.1.0</module>
+      <module>module load ncarenv</module>
+      <module>module load ncarbinlibs</module>
+      <module>module load ncarcompilers</module>
+      <module>module load slurm/17</module>
       <module>module load openmpi-slurm/3.0.0</module>
       <module>module load numpy/1.11.0</module>
       <module>module load scipy/0.18.1</module>
@@ -36,25 +39,25 @@
     </modules>
     <components>
       <component name="atm">
-	<averages_pes queue="geyser" nodes="1" pes_per_node="32" wallclock="02:00:00" memory="900G">32</averages_pes>
-	<diagnostics_pes queue="geyser" nodes="1" pes_per_node="16" wallclock="02:00:00" memory="500G">16</diagnostics_pes>
+	<averages_pes queue="geyser" nodes="4" pes_per_node="8" wallclock="02:00:00" memory="100G">32</averages_pes>
+	<diagnostics_pes queue="geyser" nodes="1" pes_per_node="16" wallclock="02:00:00" memory="100G">16</diagnostics_pes>
 	<regrid_pes queue="geyser" nodes="1" pes_per_node="6" wallclock="02:00:00" memory="100G">6</regrid_pes>
 	<obs_root>/glade/p/cesm/amwg/amwg_data</obs_root>
       </component>
       <component name="ice">
-	<averages_pes queue="geyser" nodes="1" pes_per_node="32" wallclock="02:00:00" memory="900G">32</averages_pes>
-	<diagnostics_pes queue="geyser" nodes="1" pes_per_node="4" wallclock="01:00:00" memory="400G">4</diagnostics_pes>
+	<averages_pes queue="geyser" nodes="4" pes_per_node="8" wallclock="02:00:00" memory="100G">32</averages_pes>
+	<diagnostics_pes queue="geyser" nodes="1" pes_per_node="4" wallclock="01:00:00" memory="100G">4</diagnostics_pes>
 	<obs_root>/glade/p/cesm/pcwg/ice/data</obs_root>
       </component>
       <component name="lnd">
-	<averages_pes queue="geyser" nodes="1" pes_per_node="32" wallclock="02:00:00" memory="900G">32</averages_pes>
- 	<diagnostics_pes queue="geyser" nodes="1" pes_per_node="12" wallclock="02:00:00" memory="500G">12</diagnostics_pes>
-	<regrid_pes queue="geyser" nodes="1" pes_per_node="6" wallclock="02:00:00" memory="600G">6</regrid_pes>
+	<averages_pes queue="geyser" nodes="4" pes_per_node="8" wallclock="02:00:00" memory="100G">32</averages_pes>
+ 	<diagnostics_pes queue="geyser" nodes="1" pes_per_node="12" wallclock="02:00:00" memory="100G">12</diagnostics_pes>
+	<regrid_pes queue="geyser" nodes="1" pes_per_node="6" wallclock="02:00:00" memory="100G">6</regrid_pes>
 	<obs_root>/glade/p/cesm/lmwg/diag/lnd_diag_data</obs_root>
       </component>
       <component name="ocn">
-	<averages_pes queue="geyser" nodes="1" pes_per_node="32" wallclock="02:00:00" memory="900G">32</averages_pes>
-	<diagnostics_pes queue="geyser" nodes="1" pes_per_node="16" wallclock="02:00:00" memory="500G">16</diagnostics_pes>
+	<averages_pes queue="geyser" nodes="4" pes_per_node="8" wallclock="02:00:00" memory="100G">32</averages_pes>
+	<diagnostics_pes queue="geyser" nodes="1" pes_per_node="16" wallclock="02:00:00" memory="100G">16</diagnostics_pes>
 	<obs_root>/glade/p/cesm/</obs_root>
       </component>
       <component name="ilamb">

--- a/Machines/machine_postprocess.xml
+++ b/Machines/machine_postprocess.xml
@@ -4,8 +4,8 @@
 
   <machine name="geyser" hostname="geyser">
     <!-- restricting to geyser for CMIP6 and problem with scaling of the chunking -->
-    <timeseries_pes queue="geyser" nodes="1" pes_per_node="16" wallclock="04:00:00" memory="1000G">16</timeseries_pes>
-    <xconform_pes queue="geyser" nodes="1" pes_per_node="16" wallclock="06:00:00" memory="1000G">16</xconform_pes>
+    <timeseries_pes queue="geyser" nodes="1" pes_per_node="32" wallclock="04:00:00" memory="900G">32</timeseries_pes>
+    <xconform_pes queue="geyser" nodes="1" pes_per_node="32" wallclock="06:00:00" memory="900G">32</xconform_pes>
     <mpi_command>mpiexec</mpi_command>
     <pythonpath>/glade/apps/opt/python/2.7.7/gnu-westmere/4.8.2/lib/python2.7/site-packages</pythonpath>
     <f2py fcompiler="gfortran" f77exec="/usr/bin/gfortran">f2py</f2py>
@@ -36,25 +36,25 @@
     </modules>
     <components>
       <component name="atm">
-	<averages_pes queue="geyser" nodes="1" pes_per_node="16" wallclock="02:00:00" memory="1000G">16</averages_pes>
-	<diagnostics_pes queue="geyser" nodes="1" pes_per_node="16" wallclock="02:00:00" memory="1000G">16</diagnostics_pes>
+	<averages_pes queue="geyser" nodes="1" pes_per_node="32" wallclock="02:00:00" memory="900G">32</averages_pes>
+	<diagnostics_pes queue="geyser" nodes="1" pes_per_node="16" wallclock="02:00:00" memory="500G">16</diagnostics_pes>
 	<regrid_pes queue="geyser" nodes="1" pes_per_node="6" wallclock="02:00:00" memory="100G">6</regrid_pes>
 	<obs_root>/glade/p/cesm/amwg/amwg_data</obs_root>
       </component>
       <component name="ice">
-	<averages_pes queue="geyser" nodes="1" pes_per_node="16" wallclock="02:00:00" memory="1000G">16</averages_pes>
+	<averages_pes queue="geyser" nodes="1" pes_per_node="32" wallclock="02:00:00" memory="900G">32</averages_pes>
 	<diagnostics_pes queue="geyser" nodes="1" pes_per_node="4" wallclock="01:00:00" memory="400G">4</diagnostics_pes>
 	<obs_root>/glade/p/cesm/pcwg/ice/data</obs_root>
       </component>
       <component name="lnd">
-	<averages_pes queue="geyser" nodes="1" pes_per_node="16" wallclock="02:00:00" memory="1000G">16</averages_pes>
- 	<diagnostics_pes queue="geyser" nodes="1" pes_per_node="12" wallclock="02:00:00" memory="800G">12</diagnostics_pes>
+	<averages_pes queue="geyser" nodes="1" pes_per_node="32" wallclock="02:00:00" memory="900G">32</averages_pes>
+ 	<diagnostics_pes queue="geyser" nodes="1" pes_per_node="12" wallclock="02:00:00" memory="500G">12</diagnostics_pes>
 	<regrid_pes queue="geyser" nodes="1" pes_per_node="6" wallclock="02:00:00" memory="600G">6</regrid_pes>
 	<obs_root>/glade/p/cesm/lmwg/diag/lnd_diag_data</obs_root>
       </component>
       <component name="ocn">
-	<averages_pes queue="geyser" nodes="1" pes_per_node="16" wallclock="02:00:00" memory="1000G">16</averages_pes>
-	<diagnostics_pes queue="geyser" nodes="1" pes_per_node="16" wallclock="02:00:00" memory="1000G">16</diagnostics_pes>
+	<averages_pes queue="geyser" nodes="1" pes_per_node="32" wallclock="02:00:00" memory="900G">32</averages_pes>
+	<diagnostics_pes queue="geyser" nodes="1" pes_per_node="16" wallclock="02:00:00" memory="500G">16</diagnostics_pes>
 	<obs_root>/glade/p/cesm/</obs_root>
       </component>
       <component name="ilamb">
@@ -128,13 +128,13 @@
 	<obs_root>/glade/p/cesm/</obs_root>
       </component>
       <component name="ilamb">
-	<diagnostics_pes queue="regular" nodes="1" pes_per_node="36" wallclock="01:00">36</diagnostics_pes>
-	<initialize_pes queue="share" nodes="1" pes_per_node="36" wallclock="00:10">1</initialize_pes>
+	<diagnostics_pes queue="regular" nodes="1" pes_per_node="36" wallclock="00:30:00">36</diagnostics_pes>
+	<initialize_pes queue="share" nodes="1" pes_per_node="1" wallclock="00:01:00">1</initialize_pes>
 	<obs_root>/glade/p/cesm/lmwg_dev/oleson/ILAMB/ILAMB_all</obs_root>
       </component>
       <component name="iomb">
-	<diagnostics_pes queue="regular" nodes="1" pes_per_node="36" wallclock="01:00">36</diagnostics_pes>
-	<initialize_pes queue="share" nodes="1" pes_per_node="36" wallclock="00:10">1</initialize_pes>
+	<diagnostics_pes queue="regular" nodes="1" pes_per_node="36" wallclock="00:30:00">36</diagnostics_pes>
+	<initialize_pes queue="share" nodes="1" pes_per_node="1" wallclock="00:01:00">1</initialize_pes>
 	<obs_root>/glade/p/cesm/omwg/obs_data/IOMB</obs_root>
       </component>
     </components>

--- a/Templates/batch_cheyenne.tmpl
+++ b/Templates/batch_cheyenne.tmpl
@@ -8,3 +8,5 @@
 
 export I_MPI_DEVICE=rdma
 export MPI_UNBUFFERED_STDIO=true
+
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/glade/u/apps/ch/opt/pythonpkgs/2.7/cf_units/1.1.3/gnu/6.2.0/lib

--- a/Templates/postprocess.tmpl
+++ b/Templates/postprocess.tmpl
@@ -18,19 +18,32 @@ if [ ! -e {{ virtualEnvDir }} ]; then
     exit
 fi
 
+## NOTE: the module load order and when the python virtualenv is activated is IMPORTANT!
+##       Purging the modules first clears all environment variables that might have been set
+##       by the virtualenv activation. Consequently, in order to ensure a correct environment
+##       we must activate the virtualenv *after* the purge. 
+
+## First: purge and load the default system modules that the virtualenv was built with
+
 {% for module in reset_modules %}
 {{ module }}
 {% endfor %}
+
+## Second: activate the virtualenv that contains all the non-bootstrapped dependencies
 
 cd {{ virtualEnvDir }}
 pwd
 . activate
 
+## Third: load the boot-strap modules 
+
 {% for module in modules %}
 {{ module }}
 {% endfor %}
 
+
 {% if pythonpath|length > 0 %}
+## The PYTHONPATH setting here is for libraries that are not available via modules.
 PYTHONPATH={{ pythonpath }}:$PYTHONPATH
 export PYTHONPATH
 {% endif %}

--- a/Templates/postprocess.tmpl
+++ b/Templates/postprocess.tmpl
@@ -23,19 +23,27 @@ fi
 ##       by the virtualenv activation. Consequently, in order to ensure a correct environment
 ##       we must activate the virtualenv *after* the purge. 
 
-## First: purge and load the default system modules that the virtualenv was built with
+## 1. purge and load the default system modules that the virtualenv was built with
 
 {% for module in reset_modules %}
 {{ module }}
 {% endfor %}
 
-## Second: activate the virtualenv that contains all the non-bootstrapped dependencies
+## 2. check the processName for ocn_diagnostics_geyser and set the OCNDIAG_DIAGROOTPATH 
+##    to point to the geyser virtualenv in order for the correct za compiled tool
+
+{% if "ocn_diagnostics_geyser" in processName %}
+pp_geyser_path=`./pp_config --get POSTPROCESS_PATH_GEYSER --value`
+./pp_config --set OCNDIAG_DIAGROOTPATH=$pp_geyser_path/ocn_diag
+{% endif %}
+
+## 3. activate the virtualenv that contains all the non-bootstrapped dependencies
 
 cd {{ virtualEnvDir }}
 pwd
 . activate
 
-## Third: load the boot-strap modules 
+## 4. load the boot-strap modules 
 
 {% for module in modules %}
 {{ module }}


### PR DESCRIPTION
The ocn_diagnostics_geyser batch script that is created when create_postprocess is run on cheyenne needs to set the OCNDIAG_DIAGROOTPATH
XML variable to point to the geyser virtualenv (POSTPROCESS_PATH_GEYSER/ocn_diag)
rather than the default cheyenne virtualenv (POSTPROCESS_PATH/ocn_diag) because
the zonal average tool (za) is compiled differently for each machine. 

This PR also includes a fix for running IMB on cheyenne so that the libudunits is 
included in the LD_LIBRARY_PATH. 