### PR TITLE
revert Makefile all rule to develop 

### DIFF
--- a/cesm_utils/Makefile
+++ b/cesm_utils/Makefile
@@ -1,4 +1,4 @@
-all : install
+all : develop
 
 test : FORCE
 	python -m unittest discover --start-directory cesm_utils/tests

--- a/conform/Makefile
+++ b/conform/Makefile
@@ -1,4 +1,4 @@
-all : install
+all : develop
 
 test : FORCE
 	python -m unittest discover --start-directory test

--- a/diag_utils/Makefile
+++ b/diag_utils/Makefile
@@ -1,4 +1,4 @@
-all : install
+all : develop
 
 test : FORCE
 	python -m unittest discover --start-directory diag_utils/tests

--- a/diagnostics/Makefile
+++ b/diagnostics/Makefile
@@ -1,4 +1,4 @@
-all : install
+all : develop
 
 test : FORCE
 	xmllint --schema 

--- a/timeseries/Makefile
+++ b/timeseries/Makefile
@@ -1,4 +1,4 @@
-all : install
+all : develop
 
 test : FORCE
 	python -m unittest discover --start-directory test


### PR DESCRIPTION
Not able to repeat the problem with building the virtualenv on cheyenne and the Makefile when using the rule all: develop.