### PR TITLE
update the machine PE defaults in preparation for CMIP6 

### DIFF
--- a/Machines/machine_postprocess.xml
+++ b/Machines/machine_postprocess.xml
@@ -74,8 +74,8 @@
   </machine>
 
   <machine name="cheyenne" hostname="cheyenne">
-    <timeseries_pes queue="regular" nodes="2" pes_per_node="36" wallclock="00:30:00">72</timeseries_pes>
-    <xconform_pes queue="regular" nodes="2" pes_per_node="36" wallclock="06:00:00">72</xconform_pes>
+    <timeseries_pes queue="regular" nodes="4" pes_per_node="18" wapllclock="00:30:00">72</timeseries_pes>
+    <xconform_pes queue="regular" nodes="8" pes_per_node="4" wallclock="06:00:00">32</xconform_pes>
     <mpi_command>mpiexec_mpt dplace -s 1</mpi_command>
     <pythonpath></pythonpath>
     <f2py fcompiler="gfortran" f77exec="/glade/u/apps/ch/opt/gnu/6.2.0/bin/gfortran" 
@@ -109,34 +109,34 @@
     </modules>
     <components>
       <component name="atm">
-	<averages_pes queue="regular" nodes="2" pes_per_node="36" wallclock="01:00:00">72</averages_pes>
-	<diagnostics_pes queue="regular" nodes="1" pes_per_node="36" wallclock="01:00:00">36</diagnostics_pes>
-	<regrid_pes queue="regular" nodes="1" pes_per_node="36" wallclock="01:00:00">36</regrid_pes>
+	<averages_pes queue="regular" nodes="4" pes_per_node="18" wallclock="01:00:00">72</averages_pes>
+	<diagnostics_pes queue="regular" nodes="1" pes_per_node="18" wallclock="01:00:00">18</diagnostics_pes>
+	<regrid_pes queue="regular" nodes="1" pes_per_node="16" wallclock="01:00:00">36</regrid_pes>
 	<obs_root>/glade/p/cesm/amwg/amwg_data</obs_root>
       </component>
       <component name="ice">
-	<averages_pes queue="regular" nodes="2" pes_per_node="36" wallclock="01:00:00">72</averages_pes>
-	<diagnostics_pes queue="regular" nodes="1" pes_per_node="36" wallclock="01:00:00">36</diagnostics_pes>
+	<averages_pes queue="regular" nodes="4" pes_per_node="18" wallclock="01:00:00">72</averages_pes>
+	<diagnostics_pes queue="regular" nodes="1" pes_per_node="8" wallclock="01:00:00">8</diagnostics_pes>
 	<obs_root>/glade/p/cesm/pcwg/ice/data</obs_root>
       </component>
       <component name="lnd">
-	<averages_pes queue="regular" nodes="2" pes_per_node="36" wallclock="01:00:00">72</averages_pes>
-	<diagnostics_pes queue="regular" nodes="1" pes_per_node="36" wallclock="01:00:00">36</diagnostics_pes>
-	<regrid_pes queue="regular" nodes="1" pes_per_node="36" wallclock="01:00:00">36</regrid_pes>
+	<averages_pes queue="regular" nodes="4" pes_per_node="18" wallclock="01:00:00">72</averages_pes>
+	<diagnostics_pes queue="regular" nodes="1" pes_per_node="16" wallclock="01:00:00">16</diagnostics_pes>
+	<regrid_pes queue="regular" nodes="1" pes_per_node="12" wallclock="01:00:00">12</regrid_pes>
 	<obs_root>/glade/p/cesm/lmwg/diag/lnd_diag_data</obs_root>
       </component>
       <component name="ocn">
-	<averages_pes queue="regular" nodes="2" pes_per_node="36" wallclock="01:00:00">72</averages_pes>
-	<diagnostics_pes queue="regular" nodes="1" pes_per_node="36" wallclock="01:00:00">36</diagnostics_pes>
+	<averages_pes queue="regular" nodes="4" pes_per_node="18" wallclock="01:00:00">72</averages_pes>
+	<diagnostics_pes queue="regular" nodes="1" pes_per_node="16" wallclock="01:00:00">16</diagnostics_pes>
 	<obs_root>/glade/p/cesm/</obs_root>
       </component>
       <component name="ilamb">
-	<diagnostics_pes queue="regular" nodes="1" pes_per_node="36" wallclock="00:30:00">36</diagnostics_pes>
+	<diagnostics_pes queue="regular" nodes="1" pes_per_node="8" wallclock="00:30:00">8</diagnostics_pes>
 	<initialize_pes queue="share" nodes="1" pes_per_node="1" wallclock="00:01:00">1</initialize_pes>
 	<obs_root>/glade/p/cesm/lmwg_dev/oleson/ILAMB/ILAMB_all</obs_root>
       </component>
       <component name="iomb">
-	<diagnostics_pes queue="regular" nodes="1" pes_per_node="36" wallclock="00:30:00">36</diagnostics_pes>
+	<diagnostics_pes queue="regular" nodes="1" pes_per_node="8" wallclock="00:30:00">8</diagnostics_pes>
 	<initialize_pes queue="share" nodes="1" pes_per_node="1" wallclock="00:01:00">1</initialize_pes>
 	<obs_root>/glade/p/cesm/omwg/obs_data/IOMB</obs_root>
       </component>


### PR DESCRIPTION
**IMPORTANT NOTE** - if there are memory issues, try first running with fewer MPI tasks per node