### PR TITLE
minor fix to create_postprocess for geyser

### DIFF
--- a/cesm_utils/cesm_utils/create_postprocess
+++ b/cesm_utils/cesm_utils/create_postprocess
@@ -607,8 +607,8 @@ def main(options):
     if not envDict['MACH']:
         raise OSError('create_postprocess ERROR: hostname "{0}" is not currently supported. Exiting...'.format(hostname))
 
-    # check if machine is cheyenne and if env POSTPROCESS_PATH_GEYSER is set
-    if envDict['MACH'] == 'cheyenne':
+    # check if env POSTPROCESS_PATH_GEYSER needs to be set
+    if (envDict['MACH'] == 'cheyenne' or envDict['MACH'] == 'geyser'):
         try:
             envDict["POSTPROCESS_PATH_GEYSER"] = os.environ["POSTPROCESS_PATH_GEYSER"]
         except KeyError:


### PR DESCRIPTION
The POSTPROCESS_PATH and POSTPROCESS_PATH_GEYSER environment variables 
both need to be set when running create_postprocess on either cheyenne or geyser. 

Note: when create_postprocess is run on geyser, the POSTPROCESS_PATH and the POSTPROCESS_PATH_GEYSER are the same. 

The distinction is important when running create_postprocess on cheyenne because the
batch submission scripts for geyser are included in a cheyenne postprocessing caseroot to
allow for submission of jobs to geyser from cheyenne. 