### PR TITLE
Fix for CPL_ENERGY_BAL when input variables are missing (CLM4/CLM45)

### DIFF
--- a/lnd_diag/shared/lnd_func.ncl
+++ b/lnd_diag/shared/lnd_func.ncl
@@ -152,8 +152,8 @@ begin
       qrunoff_ice_to_coupler = ptr->QRUNOFF_ICE_TO_COUPLER
       var = fsa ; trick to retain meta data
       var = fsa+flds-fire-fsh_to_coupler-eflx_lh_tot-snow_from_atm*latice+qrunoff_ice_to_coupler*latice
-      return(var)
     end if
+    return(var)
   end if
 
   if(var_name .eq. "TOTRUNOFF")then


### PR DESCRIPTION
Prevent set errors for CPL_ENERGY_BAL for versions of CLM other than CLM5 (CLM4 and CLM4.5).