### PR TITLE
fix for Issue #138

### DIFF
--- a/timeseries/timeseries/chunking.py
+++ b/timeseries/timeseries/chunking.py
@@ -9,8 +9,8 @@ from asaptools import partition
 
 def num2date(time_value, unit, calendar):
 ## fix for fractional time bounds
-    if (math.floor(time_value) != time_value):
-        time_value = int(round(time_value))
+#    if (math.floor(time_value) != time_value):
+#        time_value = int(round(time_value))
     if ('common_year' in unit):
         my_unit = unit.replace('common_year', 'day')
 ##        my_time_value = time_value * 365
@@ -150,7 +150,7 @@ def get_cesm_date(fn,t=None):
                d = 0
         elif t == 'e':
            l = len(f.variables[att['bounds']])
-           d = (f.variables[att['bounds']][l-1][1])-1
+           d = (f.variables[att['bounds']][l-1][0])
         elif t == 'ee':
            l = len(f.variables[att['bounds']])
            d = (f.variables[att['bounds']][l-1][1])


### PR DESCRIPTION
problem with chunking.py and hourly clm data. This fix looks at the bounds attribute of a variable to determine the correct time step sequence.  Tested with clm day_1, hour_1, hour_3, hour_6, min_30 and  month_1;  mosart month_1; and cism year_1 data streams. 