### PR TITLE
uncomment the time_period_freq get global attribute

### DIFF
--- a/timeseries/timeseries/chunking.py
+++ b/timeseries/timeseries/chunking.py
@@ -80,11 +80,13 @@ def get_input_dates(glob_str, comm, rank, size):
 
         # get the time_period_freq global attribute from the first file
         if first:
-            try:
+            if 'time_period_freq' in nc_atts:
                 time_period_freq = f.getncattr('time_period_freq')
-                print 'time_period_freq = ',time_period_freq
-            except:
-                print 'Global attribute time_period_freq not found - set to XML tseries_tper element'
+                if rank == 0:
+                    print 'time_period_freq = ',time_period_freq
+            else:
+                if rank == 0:
+                    print 'Global attribute time_period_freq not found - set to XML tseries_tper element'
             first = False
         f.close()
 

--- a/timeseries/timeseries/chunking.py
+++ b/timeseries/timeseries/chunking.py
@@ -80,11 +80,11 @@ def get_input_dates(glob_str, comm, rank, size):
 
         # get the time_period_freq global attribute from the first file
         if first:
-            #try:
-            #    time_period_freq = f.getncattr('time_period_freq')
-            #    print 'time_period_freq = ',time_period_freq
-            #except:
-            #    print 'Global attribute time_period_freq not found - set to XML tseries_tper element'
+            try:
+                time_period_freq = f.getncattr('time_period_freq')
+                print 'time_period_freq = ',time_period_freq
+            except:
+                print 'Global attribute time_period_freq not found - set to XML tseries_tper element'
             first = False
         f.close()
 


### PR DESCRIPTION
The chunking.py code had commented out the code to get the time_period_freq netcdf global
attribute from the first history slice file for a given output stream. This was to allow for older
datasets that did not have this attribute. @sherimickelson - is this commented out code an artifact from some of your testing?

Tested with ocean BGC data where the pop.h stream was set to annual means output rather than
the default monthly means.