### PR TITLE
recursively resolve all XML variables in the env_dict

### DIFF
--- a/Tools/pp_config
+++ b/Tools/pp_config
@@ -275,6 +275,10 @@ def main(options):
     for tree in xml_trees:
         xml_processor.xml_to_dict(tree, envDict)
 
+    # this should be done in the xml_to_dict!
+    # resolve all the xml variables
+    envDict = cesmEnvLib.readXML(case_dir, xml_filenames)
+
     # 'get' user input
     if options.get:
         entry_id = options.get[0]


### PR DESCRIPTION
the processXmlLib.xml_to_dict method needs to be flushed out correctly to recursively resolve
nested variables. Substituting this call with cesmEnvLib.readXML.