### PR TITLE
remove SALT and TEMP from ocn diags timeseries mocm climo file

### DIFF
--- a/diagnostics/diagnostics/ocn/ocn_avg_generator.py
+++ b/diagnostics/diagnostics/ocn/ocn_avg_generator.py
@@ -358,7 +358,7 @@ def createClimFiles(start_year, stop_year, in_dir, htype, tavgdir, case, tseries
         if len(averageListMoc) > 0:
             # call the pyAverager with the inVarList
             if 'MOC' in inVarList:
-                tmpInVarList = ['SALT', 'TEMP', 'MOC']
+                tmpInVarList = ['MOC']
             else:
                 tmpInVarList = ['SALT', 'TEMP']
             if main_comm.is_manager():


### PR DESCRIPTION
The pyAverager was calculating the monthly SALT, TEMP and MOC variables for the monthly moc 
file unnecessarily because the NCL only requires the MOC variable. This change ensures that the
mocm file doesn't become unnecessarily large. 