### PR TITLE
Fixes for high-res ocean diagnostics

### DIFF
--- a/ocn_diag/ncl_lib/U_eq.ncl
+++ b/ocn_diag/ncl_lib/U_eq.ncl
@@ -5,6 +5,7 @@ load "$NCLPATH/get_environment.ncl"
 load "$NCLPATH/pop_lon_shift.ncl"
 load "$NCLPATH/pop_eq_avg.ncl"
 begin
+
    fileid = addfile(file_netcdf,"r")
    uvel = fileid->UVEL(0,:,:,:)
    if (isatt(uvel,"_FillValue"))
@@ -132,6 +133,13 @@ begin
    res@trYReverse = True
    res@trYMaxF = 400.0
    res@trYMinF = 0.0
+   if ( (resolution .eq. "tx0.1v2") .or. (resolution .eq. "tx0.1v3") )then
+     ; ulon needs to be monotonically increasing and absent any missing_value
+     do i=0,3599
+      ulon(y_eq,i) = todouble(i)*0.1
+     end do
+     res@sfXArray = ulon(y_eq,:)
+   end if
    res@trXMaxF = 290.0
    res@trXMinF = 110.0
    plot1 = gsn_csm_contour(wks,temp1(:z_max,:),res)  

--- a/ocn_diag/ncl_lib/field_3d_za.ncl
+++ b/ocn_diag/ncl_lib/field_3d_za.ncl
@@ -31,7 +31,7 @@ begin
 
   n_reg = dimsizes(region_index)
 
-  field_name = [/ "TEMP",  "SALT" , "IAGE" /] 
+  field_name = [/ "TEMP",  "SALT" /]
 
   fileid = addfile(file_netcdf,"r")
   fileidtobs = addfile(file_T_obs_za,"r")
@@ -49,6 +49,9 @@ begin
 
   f_za = addfile(file_netcdf_za,"r")
 
+  if (isfilevar(f_za,"IAGE")) then
+    ListPush(field_name,"IAGE")
+  end if
   if (isfilevar(f_za,"KAPPA_ISOP")) then
     ListPush(field_name,"KAPPA_ISOP")
   end if

--- a/ocn_diag/ncl_lib/iagez.ncl
+++ b/ocn_diag/ncl_lib/iagez.ncl
@@ -9,7 +9,13 @@ begin
    print( " plotting IAGE at "+ n_depth + " depth levels")
    
    fileid = addfile(file_netcdf,"r")
-   iage = fileid->IAGE
+
+   if (isfilevar(fileid,"IAGE"))
+     iage = fileid->IAGE
+   else
+     return
+   end if
+
    if (isatt(iage,"_FillValue"))
       missing = iage@_FillValue
    else

--- a/ocn_diag/ncl_lib/sst_eq_pac_seasonal_cycle.ncl
+++ b/ocn_diag/ncl_lib/sst_eq_pac_seasonal_cycle.ncl
@@ -34,6 +34,27 @@ begin
   y_min = ind_nearest_coord(-1.5,lat(:,0),0)
   y_max = ind_nearest_coord(1.5,lat(:,0),0)
 
+  shift_needed = False
+  if ( (resolution .eq. "tx0.1v2") .or. (resolution .eq. "tx0.1v3") )then
+    shift_needed = True
+
+    field_orig = field
+    lon_orig = lon
+    lat_orig = lat
+    tarea_orig = tarea
+
+    field(:,:,:(nx-1-xs)) = field_orig(:,:,xs:nx-1)
+    field(:,:,(nx-xs):)   = field_orig(:,:,:xs-1)
+    lon(:,:(nx-1-xs))   = lon_orig(:,xs:nx-1)
+    lon(:,(nx-xs):)     = lon_orig(:,:xs-1)
+    lat(:,:(nx-1-xs))   = lat_orig(:,xs:nx-1)
+    lat(:,(nx-xs):)     = lat_orig(:,:xs-1)
+    tarea(:,:(nx-1-xs)) = tarea_orig(:,xs:nx-1)
+    tarea(:,(nx-xs):)   = tarea_orig(:,:xs-1)
+
+    xs = ind_nearest_coord(115,lon(y_eq,:),0)
+    xe = ind_nearest_coord(285,lon(y_eq,:),0)
+  end if
 
   str1 = sprintf("%.1f",abs(lat(y_min,0)))
   str2 = sprintf("%.1f",abs(lat(y_max,0)))
@@ -188,7 +209,16 @@ begin
   res@tiMainString = "ANOMALY ("+case_number+")"
   res@tmYLLabelsOn = False
   delete(res@tiYAxisString)
-  plot3 = gsn_csm_contour(wks,anom_cyc,res)
+
+  if (shift_needed) then
+    delete(res@trXMinF)
+    delete(res@trXMaxF)
+    xs = ind_nearest_coord(120,lon(y_eq,:),0)
+    xe = ind_nearest_coord(280,lon(y_eq,:),0)
+    plot3 = gsn_csm_contour(wks,anom_cyc(:,xs-1:xe+1),res)
+  else
+    plot3 = gsn_csm_contour(wks,anom_cyc,res)
+  end if
 
   panel_res = True
   panel_res@gsnMaximize = True


### PR DESCRIPTION
Several fixes for high-resolution ocean diagnostics:
- fixes U_eq.ncl for high-res grids.
- check if iage exists before trying to create 3d za for it.
- fix sst_eq_pac_seasonal_cycle for high-res grids.

Testing: ran the tool for a high res G case:  http://webext.cgd.ucar.edu/GIAF/g.e20.G.TL319_t13.control.001/ocn/diag_work_debug.21-25/MODEL_VS_OBS/