### PR TITLE
Add CLM regridding support for SE_NE120 to FV_192x288

### DIFF
--- a/diag_utils/diag_utils/diagUtilsLib.py
+++ b/diag_utils/diag_utils/diagUtilsLib.py
@@ -498,6 +498,7 @@ def lnd_regrid(climo_file, regrid_script, t, outdir, ext_dir, env):
     env['area_file']= env['new_res_'+t]+'_area.nc' 
     env['procDir']  = tmp_outdir
     env['oldres']   = env['old_res_'+t]
+    env['newres']   = env['new_res_'+t]
     env['InFile']   = os.path.basename(climo_file)
     env['OutFile']  = env['new_res_'+t]+'_'+os.path.basename(climo_file)
     env['newfn']    = env['old_res_'+t]+'_'+os.path.basename(climo_file)

--- a/lnd_diag/shared/se2fv_esmf.regrid2file.ncl
+++ b/lnd_diag/shared/se2fv_esmf.regrid2file.ncl
@@ -22,6 +22,7 @@ begin
 
     method    = getenv("method")
     oldres    = getenv("oldres")
+    newres    = getenv("newres")
 
 ;---Get 1d destination lat/lons
     LL_dir   = getenv("wgt_dir")
@@ -72,8 +73,17 @@ begin
       fMAP_dir  = LL_dir
       fMAP_file = "map_ne30np4_nomask_TO_fv0.9x1.25_nomask_aave.130917.nc"
     else
-      fMAP_dir  = LL_dir
-      fMAP_file = "map_ne120np4_nomask_TO_fv0.23x0.31_nomask_aave.140123.nc"
+      if (oldres .eq. "SE_NE120" .and. newres .eq. "FV_768x1152") then
+        fMAP_dir  = LL_dir
+        fMAP_file = "map_ne120np4_nomask_TO_fv0.23x0.31_nomask_aave.140123.nc"
+      else
+        if (oldres .eq. "SE_NE120" .and. newres .eq. "FV_192x288") then
+          fMAP_dir  = LL_dir
+          fMAP_file = "map_ne120np4_nomask_TO_fv0.9x1.25_nomask_aave.181003.nc"
+        else
+          print((/"REGRIDDING NOT SUPPORTED FOR THIS oldres to newres"/))
+        end if
+      end if
     end if
     fMAP_path = fMAP_dir + fMAP_file
     fMAP      = addfile(fMAP_path,"r")


### PR DESCRIPTION
Add CLM regridding support for SE_NE120 to FV_192x288 (the only option previously was regridding to FV_768x1152).

Tested using postprocessing case:
/gpfs/fs1/work/oleson/diagnostics/runs/Branch.E.13B1850C5CN.ne120_t12.02.sehires31
This is a model to model comparison in which both SE_NE120 cases were regridded to FV_192x288.
Diagnostics output is here:
http://webext.cgd.ucar.edu/B20TH/Branch.E.13B1850C5CN.ne120_t12.02.sehires31/lnd/Branch.E.13B1850C5CN.ne120_t12.02.sehires31.10_14-B.E.13B1850C5.ne120_t12.03.sehires31.10_14/setsIndex.html