### PR TITLE
update for netCDF4-python v1.4.2 added to ncar_pylib 

### DIFF
--- a/Machines/cheyenne_modules
+++ b/Machines/cheyenne_modules
@@ -13,7 +13,7 @@ module load ncl/6.4.0
 
 # clone the ncat virtualenv first with helper script ncar_pylib
 # use "ncar_pylib --help" to see all options
-ncar_pylib -c 20180705 ${pp_dir}/cesm-env2
+ncar_pylib -c 20181024 ${pp_dir}/cesm-env2
 
 export PYTHONPATH=${pp_dir}/cesm-env2/lib/python2.7/site-packages
 

--- a/Machines/dav_modules
+++ b/Machines/dav_modules
@@ -13,7 +13,7 @@ module load ncl/6.4.0
 
 # clone the ncat virtualenv first with helper script ncar_pylib
 # use "ncar_pylib --help" to see all options
-ncar_pylib -c 20180510 ${pp_dir}/cesm-env2
+ncar_pylib -c 20181029 ${pp_dir}/cesm-env2
 
 export PYTHONPATH=${pp_dir}/cesm-env2/lib/python2.7/site-packages
 

--- a/timeseries/timeseries/chunking.py
+++ b/timeseries/timeseries/chunking.py
@@ -71,7 +71,7 @@ def get_input_dates(glob_str, comm, rank, size):
         file_slices[fn] = len(all_t)
 
         # add all dates and which file they are located in
-        for t in all_t:
+        for t in all_t[:]:
             stream_dates[t] = fn
 
         # get all attributes of time in order to get cal and units 


### PR DESCRIPTION
fix issue #175 with MaskedArrays and character variable arrays in CISM history data and timeseries chunking. Tested with 10 years of fully coupled timeseries data on both cheyenne and DAV. 
Requires a rebuild of virtualenv and new ncar_pylib clones:

Cheyenne - 20181024
DAV - 20181029