### PR TITLE
Revive set2 regional contour plots option

### DIFF
--- a/lnd_diag/model-obs/set_2.ncl
+++ b/lnd_diag/model-obs/set_2.ncl
@@ -65,20 +65,21 @@ begin
 ;;  fyr      = getenv("clim_first_yr_1")
   sig_lvl  = getenv("sig_lvl") 
   lyr   = (fyr + nyrs)-1 ; for plotting
-  zoom  = stringtointeger(getenv("reg_contour")); # (1 = SUB, 0 = GLOBAL)
-;;  zoom  = getenv("reg_contour"); # (1 = SUB, 0 = GLOBAL)
-  if (zoom.eq.1)then
+  zoom  = stringtointeger(getenv("reg_contour")); # (0 = SUBREGION, 1 = GLOBAL)
+  if (zoom.eq.0)then
      min_lat = stringtofloat(getenv("min_lat"))
-     max_lat = stringtofloat(getenv("min_lat"))
+     max_lat = stringtofloat(getenv("max_lat"))
      min_lon = stringtofloat(getenv("min_lon"))
-     max_lon = stringtofloat(getenv("min_lon"))
-
-;;     min_lat = getenv("min_lat")
-;;     max_lat = getenv("min_lat")
-;;     min_lon = getenv("min_lon")
-;;     max_lon = getenv("min_lon")
+     max_lon = stringtofloat(getenv("max_lon"))
   end if
   seasons  = (/"DJF","JJA","MAM","SON","ANN"/)
+  if (zoom .eq. 0) then
+    res@mpLimitMode = "LatLon"
+    res@mpMinLatF = min_lat
+    res@mpMaxLatF = max_lat
+    res@mpMinLonF = min_lon
+    res@mpMaxLonF = max_lon
+  end if
 ;*************************************************
 ; common plot resources
 ;*************************************************
@@ -499,6 +500,13 @@ begin
               end if
               res = True
               res = set2Res(res)
+              if (zoom .eq. 0) then
+                res@mpLimitMode = "LatLon"
+                res@mpMinLatF = min_lat
+                res@mpMaxLatF = max_lat
+                res@mpMinLonF = min_lon
+                res@mpMaxLonF = max_lon
+              end if
               if (colormap.eq.1) then
                  res@cnFillPalette = cmap1(13:240,:)
               end if
@@ -581,6 +589,13 @@ begin
 ;                  panel 1 plot: case 1 plot
                  res = True
                  res = set2Res(res)
+                 if (zoom .eq. 0) then
+                   res@mpLimitMode = "LatLon"
+                   res@mpMinLatF = min_lat
+                   res@mpMaxLatF = max_lat
+                   res@mpMinLonF = min_lon
+                   res@mpMaxLonF = max_lon
+                 end if
 
                  if (paleo .eq. "True") then
                     res@mpDataBaseVersion = "Ncarg4_1"
@@ -683,6 +698,13 @@ begin
          
                  res = True
                  res = set2Res(res)
+                 if (zoom .eq. 0) then
+                   res@mpLimitMode = "LatLon"
+                   res@mpMinLatF = min_lat
+                   res@mpMaxLatF = max_lat
+                   res@mpMinLonF = min_lon
+                   res@mpMaxLonF = max_lon
+                 end if
          
                  if (colormap.eq.1) then
                     res@cnFillPalette = cmap1(13:240,:)
@@ -798,6 +820,13 @@ begin
                       
                  res = True
                  res = set2Res(res)
+                 if (zoom .eq. 0) then
+                   res@mpLimitMode = "LatLon"
+                   res@mpMinLatF = min_lat
+                   res@mpMaxLatF = max_lat
+                   res@mpMinLonF = min_lon
+                   res@mpMaxLonF = max_lon
+                 end if
       
                  if (colormap.eq.0) then
                     cmap = RGBtoCmap("$DIAG_RESOURCES/rgb_files/diag10.rgb")  ; read in colormap.  10 colors for case maps.

--- a/lnd_diag/model1-model2/set_2.ncl
+++ b/lnd_diag/model1-model2/set_2.ncl
@@ -62,12 +62,12 @@ begin
 ; get case names and create filenames to read in
 ;*************************************************
   sig_lvl = stringtofloat(getenv("sig_lvl") )
-  zoom  = stringtointeger(getenv("reg_contour")); # (1 = SUB, 0 = GLOBAL)
-  if (zoom.eq.1)then
+  zoom  = stringtointeger(getenv("reg_contour")); # (0 = SUBREGION, 1 = GLOBAL)
+  if (zoom.eq.0)then
      min_lat = stringtofloat(getenv("min_lat"))
-     max_lat = stringtofloat(getenv("min_lat"))
+     max_lat = stringtofloat(getenv("max_lat"))
      min_lon = stringtofloat(getenv("min_lon"))
-     max_lon = stringtofloat(getenv("min_lon"))
+     max_lon = stringtofloat(getenv("max_lon"))
   end if
   seasons = (/"DJF","JJA","MAM","SON","ANN"/)
 ;*************************************************
@@ -657,6 +657,13 @@ begin
 
               res  = True
               res  = set2ResMvM(res)
+              if (zoom .eq. 0) then
+                res@mpLimitMode = "LatLon"
+                res@mpMinLatF = min_lat
+                res@mpMaxLatF = max_lat
+                res@mpMinLonF = min_lon
+                res@mpMaxLonF = max_lon
+              end if
               if (paleo .eq. "True") then
                  res@mpDataBaseVersion = "Ncarg4_1"
                  res@mpDataSetName     =  fname
@@ -867,6 +874,13 @@ begin
               if (obsFlag .eq. 1 .and. plotObs .eq. 1) then    ; OBS  plot (if present)
                  res  = True
                  res  = set2ResMvM(res)
+                 if (zoom .eq. 0) then
+                   res@mpLimitMode = "LatLon"
+                   res@mpMinLatF = min_lat
+                   res@mpMaxLatF = max_lat
+                   res@mpMinLonF = min_lon
+                   res@mpMaxLonF = max_lon
+                 end if
                  if (paleo .eq. "True") then
                     res@mpDataBaseVersion = "Ncarg4_1"
                     res@mpDataSetName     = fname
@@ -942,6 +956,13 @@ begin
 ;               set contour levels 
               res  = True
               res  = set2ResMvM(res)
+              if (zoom .eq. 0) then
+                res@mpLimitMode = "LatLon"
+                res@mpMinLatF = min_lat
+                res@mpMaxLatF = max_lat
+                res@mpMinLonF = min_lon
+                res@mpMaxLonF = max_lon
+              end if
               res@cnFillPalette = cmap1(13:240,:)
 
               if (paleo .eq. "True") then
@@ -1031,6 +1052,13 @@ begin
 
               res  = True     ; T-Test plots
               res  = set2ResMvM(res)
+              if (zoom .eq. 0) then
+                res@mpLimitMode = "LatLon"
+                res@mpMinLatF = min_lat
+                res@mpMaxLatF = max_lat
+                res@mpMinLonF = min_lon
+                res@mpMaxLonF = max_lon
+              end if
               if (paleo .eq. "True") then
                  res@mpDataBaseVersion = "Ncarg4_1"
                  res@mpDataSetName     = fname
@@ -1126,6 +1154,13 @@ begin
 
               res  = True     ; t-test plot (3D vars)
               res  = set2ResMvM(res)
+              if (zoom .eq. 0) then
+                res@mpLimitMode = "LatLon"
+                res@mpMinLatF = min_lat
+                res@mpMaxLatF = max_lat
+                res@mpMinLonF = min_lon
+                res@mpMaxLonF = max_lon
+              end if
               if (paleo .eq. "True") then
                  res@mpDataBaseVersion = "Ncarg4_1"
                  res@mpDataSetName     = fname
@@ -1217,6 +1252,13 @@ begin
                  k = karr(lev)
                  res  = True
                  res  = set2ResMvM(res)
+                 if (zoom .eq. 0) then
+                   res@mpLimitMode = "LatLon"
+                   res@mpMinLatF = min_lat
+                   res@mpMaxLatF = max_lat
+                   res@mpMinLonF = min_lon
+                   res@mpMaxLonF = max_lon
+                 end if
                  if (paleo .eq. "True") then
                     res@mpDataBaseVersion = "Ncarg4_1"
                     res@mpDataSetName     = fname
@@ -1309,6 +1351,13 @@ begin
 
                  res  = True
                  res  = set2ResMvM(res)
+                 if (zoom .eq. 0) then
+                   res@mpLimitMode = "LatLon"
+                   res@mpMinLatF = min_lat
+                   res@mpMaxLatF = max_lat
+                   res@mpMinLonF = min_lon
+                   res@mpMaxLonF = max_lon
+                 end if
                  if (paleo .eq. "True") then
                     res@mpDataBaseVersion = "Ncarg4_1"
                     res@mpDataSetName     = fname
@@ -1387,6 +1436,13 @@ begin
 
                  res  = True    ; T-Test plot (4D)
                  res  = set2ResMvM(res)
+                 if (zoom .eq. 0) then
+                   res@mpLimitMode = "LatLon"
+                   res@mpMinLatF = min_lat
+                   res@mpMaxLatF = max_lat
+                   res@mpMinLonF = min_lon
+                   res@mpMaxLonF = max_lon
+                 end if
                  if (paleo .eq. "True") then
                     res@mpDataBaseVersion = "Ncarg4_1"
                     res@mpDataSetName     = fname


### PR DESCRIPTION
Add code to set_2.ncl in model1-model2 and model-obs to revive the option for regional contour plots as selected by the user in env_diags_lnd.xml (LNDDIAG_reg_contour).

Test case output directories are here:

http://webext.cgd.ucar.edu/I20TR/clm50_release-clm5.0.15_hrv_xsmrpool_to_atm_1deg_GSWP3V1_hist.regcontour/lnd/