### PR TITLE
Set 7 changes to account for new double-precision mosart history files

### DIFF
--- a/lnd_diag/model-obs/set_7.ncl
+++ b/lnd_diag/model-obs/set_7.ncl
@@ -141,14 +141,14 @@ begin
  stn_name              = chartostring(dChr(:,33:59))
 
  nriv  = dimsizes(no)    ; number of rivers
- rtm_vol_at_stn = new(nriv,float)
- rtm_vol_at_stn_A = new(nriv,float)
- rtm_vol_at_stn_B = new(nriv,float)
- rtm_vol_at_stn_m = new((/months,nriv/),float)
- rtm_vol_at_stn_mA = new((/months,nriv/),float)
- rtm_vol_at_stn_mB = new((/months,nriv/),float)
- rtm_stn_lat_B = new(nriv,float)
- rtm_stn_lon_B = new(nriv,float)
+ rtm_vol_at_stn = new(nriv,double)
+ rtm_vol_at_stn_A = new(nriv,double)
+ rtm_vol_at_stn_B = new(nriv,double)
+ rtm_vol_at_stn_m = new((/months,nriv/),double)
+ rtm_vol_at_stn_mA = new((/months,nriv/),double)
+ rtm_vol_at_stn_mB = new((/months,nriv/),double)
+ rtm_stn_lat_B = new(nriv,double)
+ rtm_stn_lon_B = new(nriv,double)
 
  if (rmodel1 .eq. "False") then
    if (isfilevar(inptr1a,"QCHANR")) then
@@ -236,7 +236,7 @@ begin
 ; Prepare data for table of river flow
 ;----------------------------------------------
 
- riv_data = new((/11,nriv/),"float")
+ riv_data = new((/11,nriv/),"double")
  riv_data(0,:)  = ispan(1,nriv,1)
  riv_data(1,:)  = obs_vol_at_stn
  riv_data(2,:)  = fekete_rtm_vol_at_stn
@@ -427,7 +427,7 @@ begin
  res@gsnFrame               = False               ; Do not advance frame
  res@vpKeepAspect           = False
  res@vpWidthF               = 1.2
- ydata = new((/3,months+1/),"float")
+ ydata = new((/3,months+1/),"double")
  top10riv_index = (/0,5,1,6,2,7,3,8,4,9/)
 ;----------------------------------------------
 ; Open file for plots
@@ -601,8 +601,8 @@ begin
 ; Derive zonal average of ocean discharge at 1 degree resolution
 ;----------------------------------------------
 
- qchocnr_lat_A = new(nlat/2,"float")
- qchocnr_lat_B = new(nlat/2,"float")
+ qchocnr_lat_A = new(nlat/2,"double")
+ qchocnr_lat_B = new(nlat/2,"double")
  st_lat = 0
  fn_lat = 1
  do j = 0,nlat/2-1
@@ -624,7 +624,7 @@ begin
 ; Reorder north to south 
  tmp = qchocnr_lat_A(::-1)
 
- qchocnr_acc_A = new(nlat/2,"float")
+ qchocnr_acc_A = new(nlat/2,"double")
  qchocnr_acc_A(0) = tmp(0)
  do j = 1,nlat/2-1
    qchocnr_acc_A(j) = tmp(j)+qchocnr_acc_A(j-1)
@@ -632,7 +632,7 @@ begin
  delete(tmp)
  qchocnr_acc_A = qchocnr_acc_A(::-1)
 
- qchocnr_acc_B = new(nlat/2,"float")
+ qchocnr_acc_B = new(nlat/2,"double")
  qchocnr_acc_B = -999.
 
 ;----------------------------------------------
@@ -662,11 +662,11 @@ begin
  resR@trXMinF = xminl(k)
  resR@trXMaxF = xmaxl(k)
 
- ydataR = new((/3,180/),"float")
+ ydataR = new((/3,180/),"double")
  ydataR(0,:) = qchocnr_lat_A
  ydataR(1,:) = qchocnr_lat_B
  ydataR(2,:) = ann_disch_921riv(:,disch_id(k))
- ydataL = new((/3,180/),"float")
+ ydataL = new((/3,180/),"double")
  ydataL(0,:) = qchocnr_acc_A
  ydataL(1,:) = qchocnr_acc_B
  ydataL(2,:) = acc_ann_disch_921riv(:,acc_disch_id(k))
@@ -759,7 +759,7 @@ begin
  res@gsnFrame               = False               ; Do not advance frame
  res@vpKeepAspect           = False
  res@vpWidthF               = 1.2
- ydata = new((/3,months+1/),"float")
+ ydata = new((/3,months+1/),"double")
 ;----------------------------------------------
 ; Open file for plots
 ;----------------------------------------------
@@ -779,10 +779,10 @@ begin
 ; indian, arctic, med. and black seas, global) 
 ;----------------------------------------------
  do k = 0,5
-   tmp_A = new((/months,nlat,nlon/),"float")
-   tmp_B = new((/months,nlat,nlon/),"float")
-   qchocnr_mon_A = new(months,"float")
-   qchocnr_mon_B = new(months,"float")
+   tmp_A = new((/months,nlat,nlon/),"double")
+   tmp_B = new((/months,nlat,nlon/),"double")
+   qchocnr_mon_A = new(months,"double")
+   qchocnr_mon_B = new(months,"double")
 
    do m = 0,months-1
      if (k .eq. 5) then

--- a/lnd_diag/model1-model2/set_7.ncl
+++ b/lnd_diag/model1-model2/set_7.ncl
@@ -212,12 +212,12 @@ begin
  stn_name              = chartostring(dChr(:,33:59))
 
  nriv  = dimsizes(no)    ; number of rivers
- rtm_vol_at_stn = new(nriv,float)
- rtm_vol_at_stn_A = new(nriv,float)
- rtm_vol_at_stn_B = new(nriv,float)
- rtm_vol_at_stn_m = new((/months,nriv/),float)
- rtm_vol_at_stn_mA = new((/months,nriv/),float)
- rtm_vol_at_stn_mB = new((/months,nriv/),float)
+ rtm_vol_at_stn = new(nriv,double)
+ rtm_vol_at_stn_A = new(nriv,double)
+ rtm_vol_at_stn_B = new(nriv,double)
+ rtm_vol_at_stn_m = new((/months,nriv/),double)
+ rtm_vol_at_stn_mA = new((/months,nriv/),double)
+ rtm_vol_at_stn_mB = new((/months,nriv/),double)
 
 
  if (rmodel1 .eq. "False") then
@@ -354,7 +354,7 @@ begin
 ; Prepare data for table of river flow
 ;----------------------------------------------
 
- riv_data = new((/11,nriv/),"float")
+ riv_data = new((/11,nriv/),"double")
  riv_data(0,:)  = ispan(1,nriv,1)
  riv_data(1,:)  = obs_vol_at_stn
  riv_data(2,:)  = fekete_rtm_vol_at_stn
@@ -560,7 +560,7 @@ begin
  res@gsnFrame               = False               ; Do not advance frame
  res@vpKeepAspect           = False
  res@vpWidthF               = 1.2
- ydata = new((/3,months+1/),"float")
+ ydata = new((/3,months+1/),"double")
  top10riv_index = (/0,5,1,6,2,7,3,8,4,9/)
 ;----------------------------------------------
 ; Open file for plots
@@ -734,8 +734,8 @@ begin
 ; Derive zonal average of ocean discharge at 1 degree resolution
 ;----------------------------------------------
 
- qchocnr_lat_A = new(nlat/2,"float")
- qchocnr_lat_B = new(nlat/2,"float")
+ qchocnr_lat_A = new(nlat/2,"double")
+ qchocnr_lat_B = new(nlat/2,"double")
  st_lat = 0
  fn_lat = 1
  do j = 0,nlat/2-1
@@ -766,7 +766,7 @@ begin
 ; Reorder north to south 
  tmp = qchocnr_lat_A(::-1)
 
- qchocnr_acc_A = new(nlat/2,"float")
+ qchocnr_acc_A = new(nlat/2,"double")
  qchocnr_acc_A(0) = tmp(0)
  do j = 1,nlat/2-1
    qchocnr_acc_A(j) = tmp(j)+qchocnr_acc_A(j-1)
@@ -774,7 +774,7 @@ begin
  delete(tmp)
  qchocnr_acc_A = qchocnr_acc_A(::-1)
 
- qchocnr_acc_B = new(nlat/2,"float")
+ qchocnr_acc_B = new(nlat/2,"double")
  tmp = qchocnr_lat_B(::-1)
  qchocnr_acc_B(0) = tmp(0)
  do j = 1,nlat/2-1
@@ -812,11 +812,11 @@ begin
  resR@trXMinF = xminl(k)
  resR@trXMaxF = xmaxl(k)
 
- ydataR = new((/3,180/),"float")
+ ydataR = new((/3,180/),"double")
  ydataR(0,:) = qchocnr_lat_A
  ydataR(1,:) = qchocnr_lat_B
  ydataR(2,:) = ann_disch_921riv(:,disch_id(k))
- ydataL = new((/3,180/),"float")
+ ydataL = new((/3,180/),"double")
  ydataL(0,:) = qchocnr_acc_A
  ydataL(1,:) = qchocnr_acc_B
  ydataL(2,:) = acc_ann_disch_921riv(:,acc_disch_id(k))
@@ -909,7 +909,7 @@ begin
  res@gsnFrame               = False               ; Do not advance frame
  res@vpKeepAspect           = False
  res@vpWidthF               = 1.2
- ydata = new((/3,months+1/),"float")
+ ydata = new((/3,months+1/),"double")
 ;----------------------------------------------
 ; Open file for plots
 ;----------------------------------------------
@@ -929,10 +929,10 @@ begin
 ; indian, arctic, med. and black seas, global) 
 ;----------------------------------------------
  do k = 0,5
-   tmp_A = new((/months,nlat,nlon/),"float")
-   tmp_B = new((/months,nlat,nlon/),"float")
-   qchocnr_mon_A = new(months,"float")
-   qchocnr_mon_B = new(months,"float")
+   tmp_A = new((/months,nlat,nlon/),"double")
+   tmp_B = new((/months,nlat,nlon/),"double")
+   qchocnr_mon_A = new(months,"double")
+   qchocnr_mon_B = new(months,"double")
 
    do m = 0,months-1
      if (k .eq. 5) then
@@ -1044,10 +1044,22 @@ begin
 ;----------------------------------------------
 ; Plot QCHANR
 ;----------------------------------------------
- qchanr_A!0 = "lat"
- qchanr_A&lat = lat
- qchanr_A!1 = "lon"
- qchanr_A&lon = lon
+ if (isdouble(lat) .and. isfloat(qchanr_A)) then
+   latfltA = dble2flt(lat)
+   qchanr_A!0 = "lat"
+   qchanr_A&lat = latfltA
+ else
+   qchanr_A!0 = "lat"
+   qchanr_A&lat = lat
+ end if
+ if (isdouble(lon) .and. isfloat(qchanr_A)) then
+   lonfltA = dble2flt(lon)
+   qchanr_A!1 = "lon"
+   qchanr_A&lon = lonfltA
+ else
+   qchanr_A!1 = "lon"
+   qchanr_A&lon = lon
+ end if
  res = True
  res@mpProjection = "Robinson"
  res@mpPerimOn    = False
@@ -1094,10 +1106,22 @@ begin
  res@tiMainString            = case1+" (yrs "+yrs_ave1+") "
  plot = gsn_csm_contour_map(wks, qchanr_A, res)
 
- qchanr_B!0 = "lat"
- qchanr_B&lat = lat
- qchanr_B!1 = "lon"
- qchanr_B&lon = lon
+ if (isdouble(lat) .and. isfloat(qchanr_B)) then
+   latfltB = dble2flt(lat)
+   qchanr_B!0 = "lat"
+   qchanr_B&lat = latfltB
+ else
+   qchanr_B!0 = "lat"
+   qchanr_B&lat = lat
+ end if
+ if (isdouble(lon) .and. isfloat(qchanr_B)) then
+   lonfltB = dble2flt(lon)
+   qchanr_B!1 = "lon"
+   qchanr_B&lon = lonfltB
+ else
+   qchanr_B!1 = "lon"
+   qchanr_B&lon = lon
+ end if
  res@gsnLeftString = qchanr_B@long_name
  res@gsnRightString = qchanr_B@units
  wks  = gsn_open_wks (plot_type,wkdir+"set7_"+"ANN_"+"QCHANR"+"_Bc")


### PR DESCRIPTION
MOSART history files now have double-precision variables while set_7.ncl assumes single-precision variables.  These are changes to allow for double-precision while maintaining backwards compatibility for single-precision MOSART variables.
A test case directory is here:

/gpfs/fs1/work/oleson/diagnostics/runs/b.e20.B1850.f19_g17.release_cesm2_1_0.002

Output is here:

http://webext.cgd.ucar.edu/B1850/b.e20.B1850.f19_g17.release_cesm2_1_0.002/lnd/b.e20.B1850.f19_g17.release_cesm2_1_0.002.51_180-b.e21.B1850.f09_g17.CMIP6-piControl.001.771_900/setsIndex.html