### PR TITLE
add check for trailing "/" in XML variables

### DIFF
--- a/diag_utils/diag_utils/diagUtilsLib.py
+++ b/diag_utils/diag_utils/diagUtilsLib.py
@@ -200,11 +200,12 @@ def checkHistoryFiles(tseries, dout_s_root, case, rstart_year, rstop_year, comp,
     """
     if tseries.upper() in ['T','TRUE'] :
         htype = 'series'
-##        in_dir = '{0}/{1}/proc/tseries/month_1'.format(dout_s_root, comp)
     else :
         htype = 'slice'
-##        in_dir = '{0}/{1}/hist'.format(dout_s_root, comp)
 
+    # make sure subdir does not include a trailing "/"
+    if subdir.endswith('/'):
+        subdir = subdir[:-1]
     in_dir = '{0}/{1}/{2}'.format(dout_s_root, comp, subdir)
 
     # check the in_dir directory exists 

--- a/diagnostics/diagnostics/atm/atm_avg_generator.py
+++ b/diagnostics/diagnostics/atm/atm_avg_generator.py
@@ -417,6 +417,12 @@ def initialize_envDict(envDict, caseroot, debugMsg, standalone):
     if envDict['plot_SON_climo']:
         envDict['seas'].append('SON')
 
+    if envDict['test_path_history_subdir'].endswith('/'):
+        envDict['test_path_history_subdir'] = envDict['test_path_history_subdir'][:-1]
+
+    if envDict['cntl_path_history_subdir'].endswith('/'):
+        envDict['cntl_path_history_subdir'] = envDict['cntl_path_history_subdir'][:-1]
+
     return envDict
 
 #======

--- a/diagnostics/requirements.txt
+++ b/diagnostics/requirements.txt
@@ -1,3 +1,3 @@
-jinja2==2.7.3
+jinja2>=2.10
 numpy>=1.8.1
 ilamb>=2.1


### PR DESCRIPTION
 remove trailing "/" from XML variables ATMDIAG_test_path_history_subdir and ATMDIAG_cntl_path_history_subdir which cause problem when globbing single variable timeseries files for the pyAverager.

Tested manually using pp caseroot:
`/gpfs/fs1/work/aliceb/sandboxes/runs/f.e13.FAMIPC5CN.ne30_ne30.beta06.t2`

Fixes github issue #200 

Also updated jinja2 dependency requirement to >= 2.10 due to github alert. Emailed CISL to request an update of the ncar_pylib virtualenv build for python2.7.x.