### PR TITLE
Three patches for time series generation

### DIFF
--- a/timeseries/template.timeseries
+++ b/timeseries/template.timeseries
@@ -27,7 +27,7 @@ def _main_func(description):
         env_mach_specific = case.get_env('mach_specific')
         env_workflow = case.get_env("workflow")
         overrides = {}
-        overrides["total_tasks"], overrides["num_nodes"], overrides["tasks_per_node"], overrides["thread_count"] = env_workflow.get_job_specs(job)
+        overrides["total_tasks"], overrides["num_nodes"], overrides["tasks_per_node"], overrides["thread_count"] = env_workflow.get_job_specs(case, job)
 
         # Things that will have to be matched against mpirun element attributes
         mpi_attribs = {
@@ -37,7 +37,7 @@ def _main_func(description):
             "queue" : case.get_value("JOB_QUEUE", subgroup=job),
             "unit_testing" : False
             }
-        executable, mpi_arg_list = env_mach_specific.get_mpirun(case, mpi_attribs, job, overrides=overrides)
+        executable, mpi_arg_list, _, _ = env_mach_specific.get_mpirun(case, mpi_attribs, job, overrides=overrides)
         cmd = executable+" "+" ".join(mpi_arg_list) + " " + run_exe
         os.environ["ARGS_FOR_SCRIPT"] = " --caseroot={}".format(os.path.join(caseroot,"postprocess"))
         stat = run_cmd(cmd,

--- a/timeseries/timeseries/cesm_tseries_generator.py
+++ b/timeseries/timeseries/cesm_tseries_generator.py
@@ -70,7 +70,7 @@ def commandline_options():
         err_msg = 'cesm_tseries_generator.py ERROR: invalid option --caseroot {0}'.format(options.caseroot[0])
         raise OSError(err_msg)
 
-    return options.caseroot[0], options.debug[0], options.standalone, options.backtrace
+    return options.caseroot[0], options.debug, options.standalone, options.backtrace
 
 #==============================================================================================
 # readArchiveXML - read the $CASEROOT/env_timeseries.xml file and build the pyReshaper classes


### PR DESCRIPTION
1. Added `case` argument to `env_workflow.get_job_specs()`
2. explicitly ignored last two arguments returned from
   `env_mach_specific.get_mpirun()` -- shouldn't be necessary, but I was seeing
   `ValueError: too many values to unpack` and the error went away with the
   additional `_`s
3. Remove indexing from `options.debug` in `tseries_generator`, since
   `parser.add_argument()` explicitly casts it as int; avoids
   `TypeError: 'int' object has no attribute '__getitem__'`