### PR TITLE
update DAV modules and ncar_pylib version

### DIFF
--- a/Machines/dav_modules
+++ b/Machines/dav_modules
@@ -13,7 +13,7 @@ module load ncl/6.6.2
 
 # clone the ncat virtualenv first with helper script ncar_pylib
 # use "ncar_pylib --help" to see all options
-ncar_pylib -c 20190326 ${pp_dir}/cesm-env2
+ncar_pylib -c 20190718 ${pp_dir}/cesm-env2
 
 export PYTHONPATH=${pp_dir}/cesm-env2/lib/python2.7/site-packages
 

--- a/Machines/dav_modules
+++ b/Machines/dav_modules
@@ -2,18 +2,18 @@
 
 echo "Python boot-strap modules for NCAR DAV"
 
-module load python/2.7.15
-module load intel/17.0.1
+module load python/2.7.16
+module load gnu/8.3.0
 module load ncarenv
 module load ncarcompilers
-module load impi
-module load netcdf/4.6.1
+module load openmpi/3.1.4
+module load netcdf/4.7.1
 module load nco/4.7.4
-module load ncl/6.6.2
+module load ncl/6.6.2 
 
 # clone the ncat virtualenv first with helper script ncar_pylib
 # use "ncar_pylib --help" to see all options
-ncar_pylib -c 20190718 ${pp_dir}/cesm-env2
+ncar_pylib -c 20191031 ${pp_dir}/cesm-env2
 
 export PYTHONPATH=${pp_dir}/cesm-env2/lib/python2.7/site-packages
 

--- a/Machines/machine_postprocess.xml
+++ b/Machines/machine_postprocess.xml
@@ -10,20 +10,20 @@
     <pythonpath></pythonpath>
     <f2py fcompiler="intelem" f77exec="/glade/apps/opt/modulefiles/ys/cmpwrappers/ifort">f2py</f2py>
     <za>
-      <compiler>ifort</compiler>
+      <compiler>gfortran</compiler>
       <flags>-c -g -O2</flags>
-      <include>-I/glade/u/apps/dav/opt/netcdf/4.6.1/intel/17.0.1/include</include>
-      <libs>-L/glade/u/apps/dav/opt/netcdf/4.6.1/intel/17.0.1/lib -lnetcdff -lnetcdf</libs>
+      <include>-I/glade/u/apps/dav/opt/netcdf/4.7.1/gnu/8.3.0/include</include>
+      <libs>-L/glade/u/apps/dav/opt/netcdf/4.7.1/gnu/8.3.0/lib -lnetcdff -lnetcdf</libs>
     </za>
     <reset_modules>
       <module>module purge</module>
     </reset_modules>
     <modules>
-      <module>module load intel/17.0.1</module>
+      <module>module load gnu/8.3.0</module>
       <module>module load ncarenv</module>
       <module>module load ncarcompilers</module>
-      <module>module load impi</module>
-      <module>module load netcdf/4.6.1</module>
+      <module>module load openmpi/3.1.4</module>
+      <module>module load netcdf/4.7.1</module>
       <module>module load nco/4.7.4</module>
       <module>module load ncl/6.6.2</module>
     </modules>

--- a/Tools/ration_script_dav
+++ b/Tools/ration_script_dav
@@ -14,11 +14,14 @@
 #SBATCH -o ration_test.out.%J
 
 module purge
-module load python/2.7.14
-module load intel/17.0.1
+module load python/2.7.16
+module load gnu/8.3.0
 module load ncarenv
 module load ncarcompilers
-module load impi
+module load openmpi/3.1.4
+module load netcdf/4.7.1
+module load nco/4.7.4
+module load ncl/6.6.2 
 
 
 . /gpfs/fs1/work/aliceb/sandboxes/dev/postprocessing_dav/cesm-env2/bin/activate


### PR DESCRIPTION
fixes issue with out-of-date versions of modules and ncar_pylib.  

Test: ration_script_dav and creaate_postprocess

Note: ilamb for python 2.7 requires that the setup.py be modified with:
'sympy==0.7.6',


